### PR TITLE
Add Auto Margin for Theme Icon

### DIFF
--- a/jams/templates/private/nav.html
+++ b/jams/templates/private/nav.html
@@ -1,7 +1,7 @@
 <!-- Navigation Bar -->
 <header class="navbar navbar-expand-sm navbar-light d-print-none">
   <div class="container">
-    <h1 class="navbar-brand navbar-brand-autodark d-none-navbar-horizontal pe-0 pe-md-3">
+    <h1 class="navbar-brand navbar-brand-autodark d-none-navbar-horizontal pe-0 pe-md-3 me-auto">
       <a href="{{ url_for('routes.private.general.frontend.dashboard')}}">JAMS</a>
     </h1>
     <div id="nav_theme_button" class="navbar-nav flex-row order-md-last">

--- a/jams/templates/public/nav.html
+++ b/jams/templates/public/nav.html
@@ -1,7 +1,7 @@
 <!-- Navigation Bar -->
 <header class="navbar navbar-expand-sm navbar-light d-print-none">
     <div class="container">
-        <h1 class="navbar-brand navbar-brand-autodark d-none-navbar-horizontal pe-0 pe-md-3">
+        <h1 class="navbar-brand navbar-brand-autodark d-none-navbar-horizontal pe-0 pe-md-3 me-auto">
             <a href="{{ url_for('routes.public.general.frontend.home')}}">JAMS</a>
         </h1>
         <div id="nav_theme_button" class="navbar-nav flex-row order-md-last">


### PR DESCRIPTION
Fixes issue where theme toggle icon is floating in middle of navbar
<img width="1355" alt="image" src="https://github.com/user-attachments/assets/38327f4d-243a-4ca7-bb59-9d8b451ed849">
to 
<img width="1331" alt="image" src="https://github.com/user-attachments/assets/b07678ab-1d7a-4b47-87df-750294473b8b">
