### PR TITLE
Attendance streaks

### DIFF
--- a/jams/configuration.py
+++ b/jams/configuration.py
@@ -27,6 +27,7 @@ class ConfigType(Enum):
     TIMEZONE = 'TIMEZONE',
     JOLT_ENABLED = 'JOLT_ENABLED',
     JOLT_API_KEY_ID = 'JOLT_API_KEY_ID'
+    STREAKS_ENABLED = 'STREAKS_ENABLED'
 
 
 def config_entry_exists(key:Union[str, ConfigType]):

--- a/jams/default_config/endpoints.yaml
+++ b/jams/default_config/endpoints.yaml
@@ -98,6 +98,7 @@ groups:
     description: Manages voluntter information
     read:
       get_user_attendance: routes.api_v1.private.volunteer.get_user_attendance
+      get_user_streak: routes.api_v1.private.volunteer.get_streak
     write:
       add_user_attendance: routes.api_v1.private.volunteer.add_user_attendance
       edit_user_attendance: routes.api_v1.private.volunteer.edit_user_attendance
@@ -155,6 +156,7 @@ groups:
       get_general_config: routes.api_v1.private.general.get_general_config
     write:
       edit_general_config: routes.api_v1.private.general.edit_general_config
+      recalculate_streaks: routes.api_v1.private.general.recalculate_streaks
 
   eventbrite:
     description: Manages Eventbrite integrations

--- a/jams/default_config/pages.yaml
+++ b/jams/default_config/pages.yaml
@@ -130,6 +130,7 @@ pages:
     api_endpoints:
       get_general_config:
       edit_general_config:
+      recalculate_streaks:
 
   user_management:
     endpoint: routes.frontend.private.admin.user_management

--- a/jams/models/__init__.py
+++ b/jams/models/__init__.py
@@ -1,9 +1,9 @@
 from jams.extensions import db
 
-from .auth import User, Role, Page, EndpointRule, RoleEndpointRule, PageEndpointRule, RolePage
+from .auth import User, Role, Page, EndpointRule, RoleEndpointRule, PageEndpointRule, RolePage, UserRoles
 from .management import Workshop, DifficultyLevel, WorkshopType
 from .event import Event, Location, Timeslot, EventLocation, EventTimeslot, Session, FireList
-from .volunteer import VolunteerAttendance, VolunteerSignup
+from .volunteer import VolunteerAttendance, VolunteerSignup, AttendanceStreak
 from .files import File, FileVersion, WorkshopFile
 from .audit import PrivateAccessLog, WebsocketLog
 from .config import Config

--- a/jams/models/event.py
+++ b/jams/models/event.py
@@ -1,6 +1,6 @@
 from . import db
-from sqlalchemy  import CheckConstraint, Column, String, Integer, DATE, TIME, Boolean, ForeignKey, DateTime
-from sqlalchemy.orm import relationship, backref
+from sqlalchemy  import CheckConstraint, Column, String, Integer, TIME, Boolean, ForeignKey, DateTime, event
+from sqlalchemy.orm import relationship
 from jams.util.enums import FireListPersonType
 
 class Event(db.Model):
@@ -23,7 +23,7 @@ class Event(db.Model):
     def __init__(self, name, description, date, start_date_time, end_date_time, capacity, password, active=True, external=False, external_id=None, external_url = None):
         self.name = name
         self.description = description
-        self.date = date,
+        self.date = date
         self.start_date_time = start_date_time
         self.end_date_time = end_date_time
         self.capacity = capacity

--- a/jams/models/task_scheduler.py
+++ b/jams/models/task_scheduler.py
@@ -2,7 +2,7 @@ from . import db
 from sqlalchemy  import Column, ForeignKey, String, Integer, DateTime, Boolean, JSON
 from sqlalchemy.dialects.postgresql import INTERVAL
 from sqlalchemy.orm import relationship
-from datetime import datetime, UTC, timedelta
+from datetime import datetime, UTC
 from jams.util import helper
 
 class TaskSchedulerModel(db.Model):

--- a/jams/models/volunteer.py
+++ b/jams/models/volunteer.py
@@ -74,6 +74,7 @@ class AttendanceStreak(db.Model):
     id = Column(Integer(), primary_key=True)
     user_id = Column(Integer(), ForeignKey('user.id'), nullable=False)
     streak = Column(Integer(), nullable=False, default=0)
+    longest_streak = Column(Integer(), nullable=False, default=0)
     freezes = Column(Integer(), nullable=False, default=2)
     total_attended = Column(Integer(), nullable=False, default=0)
 
@@ -82,6 +83,7 @@ class AttendanceStreak(db.Model):
     def __init__(self, user_id):
         self.user_id = user_id
         self.streak = 0
+        self.longest_streak = 0
         self.freezes = 2
         self.total_attended = 0
     
@@ -90,6 +92,7 @@ class AttendanceStreak(db.Model):
             'id': self.id,
             'user_id': self.user_id,
             'streak': self.streak,
+            'longest_streak': self.longest_streak,
             'freezes': self.freezes,
             'total_attended': self.total_attended
         }

--- a/jams/models/volunteer.py
+++ b/jams/models/volunteer.py
@@ -1,6 +1,7 @@
 from . import db
-from sqlalchemy  import Column, String, Integer, Boolean, ForeignKey, UniqueConstraint
+from sqlalchemy  import Column, DateTime, String, Integer, Boolean, ForeignKey, UniqueConstraint
 from sqlalchemy.orm import relationship
+from datetime import datetime, UTC
 
 class VolunteerAttendance (db.Model):
     __tablename__ = 'volunteer_attendance'
@@ -12,6 +13,7 @@ class VolunteerAttendance (db.Model):
     main = Column(Boolean(), nullable=True)
     packdown = Column(Boolean(), nullable=True)
     note = Column(String(255), nullable=True)
+    timestamp = Column(DateTime, nullable=True)
 
     event = relationship('Event', backref='volunteer_attendances')
     user = relationship('User', backref='volunteer_attendances')
@@ -23,6 +25,7 @@ class VolunteerAttendance (db.Model):
         self.main = main
         self.packdown = packdown
         self.note = note
+        self.timestamp = datetime.now(UTC)
 
     def to_dict(self):
         return {
@@ -32,7 +35,8 @@ class VolunteerAttendance (db.Model):
             'setup': self.setup,
             'main': self.main,
             'packdown': self.packdown,
-            'note': self.note
+            'note': self.note,
+            'timestamp': self.timestamp
         }
 
 class VolunteerSignup (db.Model):
@@ -62,4 +66,30 @@ class VolunteerSignup (db.Model):
             'event_id': self.event_id,
             'user_id': self.user_id,
             'session_id': self.session_id
+        }
+
+class AttendanceStreak(db.Model):
+    __tablename__ = 'attendance_streak'
+
+    id = Column(Integer(), primary_key=True)
+    user_id = Column(Integer(), ForeignKey('user.id'), nullable=False)
+    streak = Column(Integer(), nullable=False, default=0)
+    freezes = Column(Integer(), nullable=False, default=2)
+    total_attended = Column(Integer(), nullable=False, default=0)
+
+    user = relationship('User', backref='attendance_streak')
+
+    def __init__(self, user_id):
+        self.user_id = user_id
+        self.streak = 0
+        self.freezes = 2
+        self.total_attended = 0
+    
+    def to_dict(self):
+        return {
+            'id': self.id,
+            'user_id': self.user_id,
+            'streak': self.streak,
+            'freezes': self.freezes,
+            'total_attended': self.total_attended
         }

--- a/jams/routes/api_v1/private/general.py
+++ b/jams/routes/api_v1/private/general.py
@@ -55,6 +55,7 @@ def edit_general_config():
     return jsonify({'data': config})
 
 @bp.route('/app/recalculate_streaks', methods=['POST'])
+@api_route
 def recalculate_streaks():
     if not get_config_value(ConfigType.STREAKS_ENABLED):
         return jsonify({'message': 'Streaks are not currently enabled'})

--- a/jams/routes/api_v1/private/volunteer.py
+++ b/jams/routes/api_v1/private/volunteer.py
@@ -1,8 +1,8 @@
 # API is for serving data to Typscript/Javascript
 from flask import Blueprint, request, jsonify, abort
-from flask_security import login_required
+from flask_security import current_user
 from jams.decorators import api_route, protect_user_updates
-from jams.models import db, VolunteerAttendance, VolunteerSignup, Event, User
+from jams.models import db, VolunteerAttendance, VolunteerSignup, Event, User, AttendanceStreak
 from jams.models.event import FireList
 from jams.util import helper
 
@@ -184,3 +184,8 @@ def remove_volunteer_signup(event_id, user_id, session_id):
     return jsonify({
         'message': 'Volunteer Signup Entry has been successfully removed'
     })
+
+@bp.route('/volunteers/me/streak', methods=['GET'])
+def get_streak():
+    streak = AttendanceStreak.query.filter_by(user_id=current_user.id).first_or_404()
+    return jsonify({'data': streak.to_dict()})

--- a/jams/routes/api_v1/private/volunteer.py
+++ b/jams/routes/api_v1/private/volunteer.py
@@ -187,5 +187,8 @@ def remove_volunteer_signup(event_id, user_id, session_id):
 
 @bp.route('/volunteers/me/streak', methods=['GET'])
 def get_streak():
+    if not current_user.is_authenticated:
+        return jsonify({'message': 'Please Login to access this'}), 403
+    
     streak = AttendanceStreak.query.filter_by(user_id=current_user.id).first_or_404()
     return jsonify({'data': streak.to_dict()})

--- a/jams/seeder.py
+++ b/jams/seeder.py
@@ -1,6 +1,7 @@
 import os
 import string
 from jams.models import db, User, Role, Workshop, Event, Location, Timeslot, DifficultyLevel, WorkshopType
+from jams.util.database import create_event
 from jams.endpoint_loader import generate_full_rbac
 from jams.configuration import ConfigType, set_config_value
 from flask_security.utils import hash_password
@@ -113,7 +114,7 @@ def seed_events():
         start = datetime.time(hour=13, minute=0, second=0)
         end = datetime.time(hour=17, minute=0, second=0)
         capacity = 50
-        event = Event(name="Jam", description="This is a Test event for Jam", date=date, start_date_time=start, end_date_time=end, capacity=capacity, password="jam123")
+        event = create_event(name="Jam", description="This is a Test event for Jam", date=date, start_date_time=start, end_date_time=end, capacity=capacity, password="jam123")
         db.session.add(event)
     
     # Check if the coder dojo event already exists
@@ -122,7 +123,7 @@ def seed_events():
         start = datetime.time(hour=18, minute=0, second=0)
         end = datetime.time(hour=20, minute=0, second=0)
         capacity = 50
-        event = Event(name="Coder Dojo", description="Coder dojo test event", date=date, start_date_time=start, end_date_time=end, capacity=capacity, password="password123")
+        event = create_event(name="Coder Dojo", description="Coder dojo test event", date=date, start_date_time=start, end_date_time=end, capacity=capacity, password="password123")
         db.session.add(event)
     
     db.session.commit()

--- a/jams/static/css/admin/settings/settings_general.css
+++ b/jams/static/css/admin/settings/settings_general.css
@@ -1,38 +1,46 @@
 .table-responsive th.setting-column {
-    width: 20%;
+    width: 15%;
 }
 
 .table-responsive th.description-column {
-    width: 50%;
+    width: 45%;
 }
 
 .table-responsive th.value-column {
-    width: 30%;
+    width: 20%;
+}
+
+.table-responsive th.value-column {
+    width: 20%;
 }
 
 /* Tablet (Medium screens) */
 @media (max-width: 1000px) {
     .table-responsive th.setting-column {
-        width: 30%;
+        width: 25%;
     }
 
     .table-responsive th.description-column {
-        width: 30%;
+        width: 20%;
     }
 
     .table-responsive th.value-column {
-        width: 50%;
+        width: 45%;
     }
 
     .table-responsive td.description-column {
-        width: 30%;
+        width: 20%;
+    }
+
+    .table-responsive th.value-column {
+        width: 20%;
     }
 }
 
 /* Mobile (Smaller screens) */
 @media (max-width: 600px) {
     .table-responsive th.setting-column {
-        width: 30%;
+        width: 20%;
     }
 
     .table-responsive th.description-column {
@@ -40,10 +48,18 @@
     }
 
     .table-responsive th.value-column {
-        width: 70%;
+        width: 40%;
+    }
+
+    .table-responsive th.value-column {
+        width: 40%;
     }
 
     .table-responsive td.description-column {
+        display: none;
+    }
+
+    .action-text {
         display: none;
     }
 }

--- a/jams/static/css/widgets/streak.css
+++ b/jams/static/css/widgets/streak.css
@@ -1,0 +1,70 @@
+.streak-content {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 20px;
+    margin-bottom: 20px;
+    position: relative;
+}
+
+.flame-overlay {
+    position: relative;
+    display: inline-block;
+    width: 100px;
+    height: 100px;
+}
+
+.streak-flame-icon {
+    position: absolute;
+    left: 0;
+    top: 0;
+    width: 100%;
+    height: 100%;
+}
+
+.outer-flame {
+    font-size: 100px;
+    color: #FF4500;
+    z-index: 1;
+}
+
+.no-flame {
+    font-size: 100px;
+    color: #333;
+    z-index: 1;
+}
+
+.inner-flame {
+    font-size: 78px;
+    color: #FFD700;
+    z-index: 2;
+    top: 23%;
+    left: 10%;
+    transform: translate(-10%, -10%);
+}
+
+.streak-number-good {
+    font-size: 72px;
+    font-weight: bold;
+    background: linear-gradient(180deg, #FFD700, #FF4500);
+    -webkit-background-clip: text; /* Use the gradient as the text color */
+    -webkit-text-fill-color: transparent; /* Make the actual text color transparent */
+}
+
+.streak-number-bad {
+    font-size: 72px;
+    font-weight: bold;
+    color: #333;
+}
+
+
+.freeze-info {
+    font-size: 18px;
+    color: #555;
+}
+
+.freeze-icon {
+    color: #1E90FF;
+    margin-right: 8px;
+    font-size: 20px;
+}

--- a/jams/static/ts/admin/settings/settings_general.ts
+++ b/jams/static/ts/admin/settings/settings_general.ts
@@ -1,4 +1,4 @@
-import { editGeneralConfig, getGeneralConfig } from "@global/endpoints";
+import { editGeneralConfig, getGeneralConfig, recalculateStreaks } from "@global/endpoints";
 import { GeneralConfig } from "@global/endpoints_interfaces";
 import { errorToast, isDefined, successToast } from "@global/helper";
 import { allTimezones } from "@global/timezones";
@@ -9,8 +9,9 @@ function checkIfConentUpdated() {
     const saveButton = document.getElementById('save-button') as HTMLButtonElement
 
     const locationSelect = document.getElementById('loc-select') as HTMLSelectElement
+    const streaksSwitch = document.getElementById('toggle-streaks-switch') as HTMLInputElement
 
-    if (locationSelect.value !== currentConfig.TIMEZONE) {
+    if (locationSelect.value !== currentConfig.TIMEZONE || streaksSwitch.checked !== currentConfig.STREAKS_ENABLED) {
         saveButton.disabled = false
     } else {
         saveButton.disabled = true
@@ -39,26 +40,51 @@ function populateLocationSelect() {
     }
 }
 
+function populateStreaksSection() {
+    const streaksSwitch = document.getElementById('toggle-streaks-switch') as HTMLInputElement
+    const refreshButton = document.getElementById('streak-refresh-button') as HTMLButtonElement
+
+    streaksSwitch.checked = currentConfig.STREAKS_ENABLED
+
+    refreshButton.disabled = !currentConfig.STREAKS_ENABLED
+}
+
 async function setupPage() {
     if (!currentConfig) {
         currentConfig = await getGeneralConfig()
     }
 
     populateLocationSelect()
+    populateStreaksSection()
 }
 
 function generalConfigSaveOnClick() {
     const locationSelect = document.getElementById('loc-select') as HTMLSelectElement
+    const streaksSwitch = document.getElementById('toggle-streaks-switch') as HTMLInputElement
 
     const data:GeneralConfig = {
-        TIMEZONE: locationSelect.value
+        TIMEZONE: locationSelect.value,
+        STREAKS_ENABLED: streaksSwitch.checked
     }
 
     editGeneralConfig(data).then((response) => {
+        currentConfig = response
         successToast('Config Successfully Updated')
+
+        populateStreaksSection()
+        checkIfConentUpdated()
     }).catch( () => {
         errorToast()
     }) 
+}
+
+function recalculateStreaksOnClick() {
+    recalculateStreaks().then((response) => {
+        successToast(response.message)
+    }).catch((error) => {
+        const errorMessage = error.responseJSON ? error.responseJSON.message : 'An unknown error occurred';
+        errorToast(errorMessage)
+    })
 }
 
 // Event Listeners
@@ -68,5 +94,6 @@ document.addEventListener("DOMContentLoaded", () => {
     if (isDefined(window)) {
         (<any>window).checkIfConentUpdated = checkIfConentUpdated;
         (<any>window).generalConfigSaveOnClick = generalConfigSaveOnClick;
+        (<any>window).recalculateStreaksOnClick = recalculateStreaksOnClick;
     }
 });

--- a/jams/static/ts/global/endpoints.ts
+++ b/jams/static/ts/global/endpoints.ts
@@ -2262,7 +2262,7 @@ export function getGeneralConfig():Promise<GeneralConfig> {
             url: `${baseURL}/app/config`,
             type: 'GET',
             success: function (response) {
-                resolve(response.config)
+                resolve(response.data)
             },
             error: function (error) {
                 console.log('Error fetching data:', error);
@@ -2280,7 +2280,7 @@ export function editGeneralConfig(data:Partial<GeneralConfig>):Promise<GeneralCo
             data: JSON.stringify(data),
             contentType: 'application/json',
             success: function (response) {
-                resolve(response)
+                resolve(response.data)
             },
             error: function (error) {
                 console.log('Error fetching data:', error);
@@ -2329,5 +2329,21 @@ export function getIconData(filename:string):Promise<string> {
             }
         })
     })
+}
+
+export function recalculateStreaks():Promise<ApiResponse<any>> {
+    return new Promise((resolve, reject) => {
+        $.ajax({
+            url: `${baseURL}/app/recalculate_streaks`,
+            type: 'POST',
+            success: function (response) {
+                resolve(response)
+            },
+            error: function (error) {
+                console.log('Error fetching data:', error);
+                reject(error)
+            }
+        });
+    });
 }
 // #endregion

--- a/jams/static/ts/global/endpoints.ts
+++ b/jams/static/ts/global/endpoints.ts
@@ -37,7 +37,8 @@ import {
     FireListEntry,
     sessionSettings,
     JOLTStatus,
-    JOLTConfig
+    JOLTConfig,
+    StreadData
 } from "@global/endpoints_interfaces";
 import { formatDate } from "./helper";
 
@@ -2278,6 +2279,26 @@ export function editGeneralConfig(data:Partial<GeneralConfig>):Promise<GeneralCo
             type: 'PATCH',
             data: JSON.stringify(data),
             contentType: 'application/json',
+            success: function (response) {
+                resolve(response)
+            },
+            error: function (error) {
+                console.log('Error fetching data:', error);
+                reject(error)
+            }
+        });
+    });
+}
+
+// #endregion
+
+// #region Streaks
+
+export function getVolunteerStreak():Promise<ApiResponse<StreadData>> {
+    return new Promise((resolve, reject) => {
+        $.ajax({
+            url: `${baseURL}/volunteers/me/streak`,
+            type: 'GET',
             success: function (response) {
                 resolve(response)
             },

--- a/jams/static/ts/global/endpoints_interfaces.ts
+++ b/jams/static/ts/global/endpoints_interfaces.ts
@@ -339,3 +339,11 @@ export interface JOLTStatus {
     error:string
     local_ip:string
 }
+
+export interface StreadData {
+    id:number
+    user_id:number
+    streak:number
+    freezes:number
+    total_attended:number
+}

--- a/jams/static/ts/global/endpoints_interfaces.ts
+++ b/jams/static/ts/global/endpoints_interfaces.ts
@@ -315,6 +315,7 @@ export interface AttendeeSignup {
 
 export interface GeneralConfig {
     TIMEZONE?:string
+    STREAKS_ENABLED?:boolean
 }
 
 export interface FireListEntry {

--- a/jams/static/ts/global/endpoints_interfaces.ts
+++ b/jams/static/ts/global/endpoints_interfaces.ts
@@ -345,6 +345,7 @@ export interface StreadData {
     id:number
     user_id:number
     streak:number
+    longest_streak:number
     freezes:number
     total_attended:number
 }

--- a/jams/static/ts/widgets/streak.ts
+++ b/jams/static/ts/widgets/streak.ts
@@ -1,0 +1,87 @@
+import { getEvent, getNextEvent, getVolunteerStreak } from "@global/endpoints";
+import { StreadData } from "@global/endpoints_interfaces";
+
+let widget:HTMLDivElement = null
+let streakData:StreadData = null
+
+async function populateStreakWidget() {
+    const streakGoodIcon = widget.querySelector('#streak-good-icon') as HTMLDivElement
+    const streakBadIcon = widget.querySelector('#streak-bad-icon') as HTMLDivElement
+    const streakCount = widget.querySelector('#streak-count') as HTMLDivElement
+    const freezeCount = widget.querySelector('#freeze-count') as HTMLElement
+    const freezeWord = widget.querySelector('#freeze-word') as HTMLSpanElement
+
+    const response = await getVolunteerStreak()
+    streakData = response.data
+
+    if (streakData.streak > 0) {
+        streakBadIcon.style.display = 'none'
+        streakGoodIcon.style.display = 'block'
+        streakCount.classList.remove('streak-number-bad')
+        streakCount.classList.add('streak-number-good')
+    } else {
+        streakBadIcon.style.display = 'block'
+        streakGoodIcon.style.display = 'none'
+        streakCount.classList.add('streak-number-bad')
+        streakCount.classList.remove('streak-number-good')
+    }
+
+    streakCount.innerHTML = String(streakData.streak)
+    freezeCount.innerHTML = String(streakData.freezes)
+
+    if (streakData.freezes === 1) {
+        freezeWord.innerHTML = 'freeze'
+    } else {
+        freezeWord.innerHTML = 'freezes'
+    }
+}
+
+function timeUntil(targetDateISO: string): string {
+    const currentDate = new Date()
+    const targetDate = new Date(targetDateISO)
+
+    let delta = Math.max(0, targetDate.getTime() - currentDate.getTime())
+
+    const seconds = Math.floor((delta / 1000) % 60)
+    const minutes = Math.floor((delta / (1000 * 60)) % 60)
+    const hours = Math.floor((delta / (1000 * 60 * 60)) % 24)
+    const days = Math.floor((delta / (1000 * 60 * 60 * 24)) % 30)
+    const months = Math.floor(delta / (1000 * 60 * 60 * 24 * 30))
+
+    const parts = [];
+    if (months > 0) parts.push(`${months} month${months > 1 ? "s" : ""}`)
+    if (days > 0) parts.push(`${days} day${days > 1 ? "s" : ""}`)
+    if (hours > 0) parts.push(`${hours} hour${hours > 1 ? "s" : ""}`)
+    if (minutes > 0) parts.push(`${minutes} minute${minutes > 1 ? "s" : ""}`)
+    if (seconds > 0) parts.push(`${seconds} second${seconds > 1 ? "s" : ""}`)
+
+    if (parts.length === 0) {
+        return "The target date is now or has passed."
+    } else if (parts.length === 1) {
+        return parts[0]
+    } else {
+        return parts.slice(0, -1).join(", ") + " and " + parts.slice(-1)
+    }
+}
+
+// Event listeners
+document.addEventListener("DOMContentLoaded", async function () {
+    widget = document.getElementById('streak-widget') as HTMLDivElement
+    const timeUntilText = widget.querySelector('#time-until') as HTMLParagraphElement
+
+    await populateStreakWidget()
+
+    const nextEventIdResponse = await getNextEvent()
+    const nextEventId = nextEventIdResponse.data
+
+    const event = await getEvent(nextEventId)
+    
+    const currentDate = new Date(event.date)
+    const nextStreakUpdateDate = new Date(currentDate)
+    nextStreakUpdateDate.setUTCDate(currentDate.getUTCDate() + 1)
+
+    window.setInterval(() => {
+        const timeUntilString = timeUntil(nextStreakUpdateDate.toISOString())
+        timeUntilText.innerHTML = `Next Update in: ${timeUntilString}`
+    })
+});

--- a/jams/templates/private/admin/settings/settings-general.html
+++ b/jams/templates/private/admin/settings/settings-general.html
@@ -16,6 +16,7 @@
                     <th class="setting-column">Setting</th>
                     <th class="description-column">Description</th>
                     <th class="value-column">Value</th>
+                    <th class="action-column">Action</th>
                 </tr>
             </thead>
             <tbody>
@@ -30,6 +31,27 @@
                         <select id="loc-select" class="form-control form-select" onchange="checkIfConentUpdated()">
                         </select>
                     </td>
+                    <td>N/A</td>
+                </tr>
+                <tr>
+                    <td class="setting-column">
+                        <p>Volunteer Streaks</p>
+                    </td>
+                    <td class="description-column">
+                        <label class="text-secondary">Motivate volunteers to attend events consistently by enabling streaks. Volunteers build a streak by attending consecutive events where they are signed up to a workshop, checked in, and have their attendance marked. Streaks update at midnight after each event, and volunteers are allowed two streak freezes to retain their progress.</label>
+                    </td>
+                    <td class="value-column">
+                        <label class="form-check form-switch">
+                            <input id="toggle-streaks-switch" class="form-check-input" type="checkbox"
+                            oninput="checkIfConentUpdated()">
+                        </label>
+                    </td>
+                    <td>
+                        <button id="streak-refresh-button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#confirm-recalculate-streaks">
+                            <i class="ti ti-refresh-alert"></i>
+                            <span class="ms-2 action-text">Recalculate Streaks</span>
+                        </button>
+                    </td>
                 </tr>
             </tbody>
         </table>
@@ -38,6 +60,36 @@
     <button id="save-button" class="btn btn-primary" onclick="generalConfigSaveOnClick()"
                 disabled>Save</button>
 </div>
+
+<div id="confirm-recalculate-streaks" class="modal modal-blur fade" id="modal-small" tabindex="-1" style="display: none;"
+        aria-hidden="true">
+        <div class="modal-dialog modal-sm modal-dialog-centered" role="document">
+            <div class="modal-content">
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                <div class="modal-status bg-danger"></div>
+                <div class="modal-body text-center py-4">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none"
+                        stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+                        class="icon mb-2 text-danger icon-lg">
+                        <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
+                        <path d="M12 9v4"></path>
+                        <path
+                            d="M10.363 3.591l-8.106 13.534a1.914 1.914 0 0 0 1.636 2.871h16.214a1.914 1.914 0 0 0 1.636 -2.87l-8.106 -13.536a1.914 1.914 0 0 0 -3.274 0z">
+                        </path>
+                        <path d="M12 16h.01"></path>
+                    </svg>
+                    <div class="modal-title">Are you sure?</div>
+                    <div>Recalculating streaks will reset all volunteer streaks and recalculate them based on attendance at past events, processed in chronological order. This is useful when enabling streaks after hosting events without streaks enabled</div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-outline-danger" data-bs-dismiss="modal" onclick="recalculateStreaksOnClick()">Yes,
+                        Recalculate</button>
+                    <button type="button" class="btn btn-link link-secondary ms-auto"
+                        data-bs-dismiss="modal">Cancel</button>
+                </div>
+            </div>
+        </div>
+    </div>
 
 <script src="{{ url_for('static', filename='js/admin/settings/settings_general.js') }}" type="module"
     defer></script>

--- a/jams/templates/private/dashboard.html
+++ b/jams/templates/private/dashboard.html
@@ -9,7 +9,9 @@
   </h2>
 
 <div class="row row-deck row-cards">
+    {% if get_config_value('STREAKS_ENABLED') %}
     {% include 'widgets/streak.html' %}
+    {% endif %}
 </div>
 
 

--- a/jams/templates/private/dashboard.html
+++ b/jams/templates/private/dashboard.html
@@ -4,30 +4,12 @@
 
 {% block content %}
 
+<h2 class="page-title mb-3">
+    Dashboard
+  </h2>
+
 <div class="row row-deck row-cards">
-    <div class="col-4">
-        <div class="card">
-            <div class="card-body" style="height: 10rem">
-                <h1>Dashboard</h1>
-                <p>This is the dashboard page!</p>
-            </div>
-        </div>
-    </div>
-    <div class="col-4">
-        <div class="card">
-            <div class="card-body" style="height: 10rem"></div>
-        </div>
-    </div>
-    <div class="col-4">
-        <div class="card">
-            <div class="card-body" style="height: 10rem"></div>
-        </div>
-    </div>
-    <div class="col-12">
-        <div class="card">
-            <div class="card-body" style="height: 10rem"></div>
-        </div>
-    </div>
+    {% include 'widgets/streak.html' %}
 </div>
 
 

--- a/jams/templates/widgets/streak.html
+++ b/jams/templates/widgets/streak.html
@@ -1,0 +1,32 @@
+<div id="streak-widget" class="col-12 col-md-3">
+    <div class="card">
+        <div class="card-header">
+            <div>
+                <h2>Streak</h2>
+                <p id="time-until" class="text-secondary ms-auto mt-1">Updates in 1 hour 30 minutes</p>
+            </div>
+        </div>
+
+        <div class="card-body text-center">
+            <div class="streak-content">
+                <div class="flame-overlay">
+                    <div id="streak-good-icon" style="display: none;">
+                        <i class="ti ti-flame streak-flame-icon outer-flame"></i>
+                        <i class="ti ti-flame streak-flame-icon inner-flame"></i>
+                    </div>
+                    <div id="streak-bad-icon">
+                        <i class="ti ti-flame streak-flame-icon no-flame"></i>
+                    </div>
+                </div>
+                <span id="streak-count" class="streak-number-bad">0</span>
+            </div>
+            <p class="freeze-info">
+                <i class="ti ti-snowflake freeze-icon"></i>
+                You have <strong id="freeze-count">2</strong> <span id="freeze-word">freezes</span> left.
+            </p>
+        </div>
+    </div>
+</div>
+
+<script src="{{ url_for('static', filename='js/widgets/streak.js') }}" defer></script>
+<link rel="stylesheet" href="{{ url_for('static', filename='css/widgets/streak.css') }}">

--- a/jams/util/database.py
+++ b/jams/util/database.py
@@ -1,0 +1,22 @@
+from jams.models import db, Event
+from jams.util import helper
+
+def create_event(name, description, date, start_date_time, end_date_time, capacity, password, active=True, external=False, external_id=None, external_url = None):
+    event = Event(
+        name=name,
+        description=description,
+        date=date,
+        start_date_time=start_date_time,
+        end_date_time=end_date_time,
+        capacity=capacity, password=password,
+        active=active, external=external,
+        external_id=external_id,
+        external_url=external_url
+    )
+
+    db.session.add(event)
+    db.session.commit()
+
+    helper.schedule_streaks_update_task(event)
+
+    return event

--- a/jams/util/helper.py
+++ b/jams/util/helper.py
@@ -736,6 +736,10 @@ def add_to_streak(user_id, add_freeze=True):
 
         if attendance_streak.freezes > 2:
             attendance_streak.freezes = 2
+
+    # Check if this is the longest streak
+    if attendance_streak.streak > attendance_streak.longest_streak:
+        attendance_streak.longest_streak = attendance_streak.streak
     
 
 def freeze_or_break_streak(user_id):

--- a/jams/util/helper.py
+++ b/jams/util/helper.py
@@ -748,7 +748,7 @@ def freeze_or_break_streak(user_id):
         attendance_streak = AttendanceStreak(user_id)
         db.session.add(attendance_streak)
     else:
-        if attendance_streak.freezes > 0:
+        if attendance_streak.freezes > 0 and attendance_streak.streak > 0:
             attendance_streak.freezes -= 1
         else:
             attendance_streak.streak = 0
@@ -802,7 +802,7 @@ def recalculate_streaks():
             streak.freezes = 2
             streak.total_attended = 0
 
-        events = Event.query.all()
+        events = Event.query.filter(Event.date <= date.today()).order_by(Event.date.asc()).all()
         for event in events:
             calculate_streaks(event.id)
     except Exception as e:

--- a/jams/util/task_scheduler_funcs.py
+++ b/jams/util/task_scheduler_funcs.py
@@ -7,3 +7,11 @@ def update_event_attendees_task(event_id):
         raise Exception('Requested event does not exist in the database')
     
     sync_all_attendees_at_event(external_event_id=event.external_id)
+
+def calculate_streaks_for_event_task(event_id):
+    from jams.util.helper import calculate_streaks
+    event:Event = Event.query.filter_by(id=event_id).first()
+    if not event:
+        raise Exception('Requested event does not exist in the database')
+    
+    calculate_streaks(event_id)


### PR DESCRIPTION
This PR adds streaks into JAMS.

They are Duolingo style streaks. Attending an event will add 1 to your streak. There are streak freezes (max of 2) that allow you to miss an event without breaking your streak. However if you have no freezes left, your streak will be broken and return to 0.

In order to qualify for a streak, you need to meet the following criteria:
- Have your attendance show that you are going to the main event
- Be signed up to at least 1 workshop in that event
- Be checked in on the fire list

The streaks system uses the task scheduler to automatically calculate users streaks at the end of an event (midnight UTC to be exact)

There is a section on the settings page to enable/disable streaks. From here, you can also recalculate streaks which will go through each event in chronological order and work out every users streaks. This is a manual button.

Screenshots:
![image](https://github.com/user-attachments/assets/ee090fd3-d8a5-4634-918b-d5c0a1acc79d)

![image](https://github.com/user-attachments/assets/b968fd1e-25a3-4e90-b57e-525754ee5435)
