### PR TITLE
Fix Websocket server

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,4 @@ setuptools
 requests
 Authlib
 pytz
-websockets
+websockets==13.0


### PR DESCRIPTION
This PR sets the web sockets module version to 13.0.
There seems to be some issue with 14. Will have to investigate further in the future