### PR TITLE
Order ID Account Linking

### DIFF
--- a/jams/models/attendee.py
+++ b/jams/models/attendee.py
@@ -38,9 +38,9 @@ class Attendee(db.Model):
     
     def link_to_account(self):
         # Link attendee to attendee account
-        account = AttendeeAccount.query.filter_by(email=self.email).first()
+        account =  db.session.query(AttendeeAccount).join(Attendee).filter(Attendee.external_order_id == self.external_order_id).first()
         if not account:
-            account = db.session.query(AttendeeAccount).join(Attendee).filter(Attendee.external_order_id == self.external_order_id).first()
+            account = AttendeeAccount.query.filter_by(email=self.email).first()
             
         if not account:
             account = AttendeeAccount(email=self.email)

--- a/jams/static/ts/widgets/streak.ts
+++ b/jams/static/ts/widgets/streak.ts
@@ -71,17 +71,20 @@ document.addEventListener("DOMContentLoaded", async function () {
 
     await populateStreakWidget()
 
-    const nextEventIdResponse = await getNextEvent()
-    const nextEventId = nextEventIdResponse.data
+    getNextEvent().then(async (response) => {
+        const nextEventId = response.data
 
-    const event = await getEvent(nextEventId)
-    
-    const currentDate = new Date(event.date)
-    const nextStreakUpdateDate = new Date(currentDate)
-    nextStreakUpdateDate.setUTCDate(currentDate.getUTCDate() + 1)
+        const event = await getEvent(nextEventId)
+        
+        const currentDate = new Date(event.date)
+        const nextStreakUpdateDate = new Date(currentDate)
+        nextStreakUpdateDate.setUTCDate(currentDate.getUTCDate() + 1)
 
-    window.setInterval(() => {
-        const timeUntilString = timeUntil(nextStreakUpdateDate.toISOString())
-        timeUntilText.innerHTML = `Next Update in: ${timeUntilString}`
+        window.setInterval(() => {
+            const timeUntilString = timeUntil(nextStreakUpdateDate.toISOString())
+            timeUntilText.innerHTML = `Next Update in: ${timeUntilString}`
+        })
+    }).catch(() => {
+        timeUntilText.style.display = 'none'
     })
 });


### PR DESCRIPTION
This PR fixes how attendees are linked with attendee accounts the new flow is:

- If there is an account with an attendee with the same order ID in it, the new attendee gets linked to that account.
- If not, it checks for an account with the same email

Attendee login logic has now also slightly changed as an account can have multiple emails associated with it:
- First it checks for an account that has either its own email or the email of one of its existing attendees that matches with the inputted email. It does this while checking if the account has access to the current event.
- If this fails, it looks to see if there is an account that matches which doesn't have access to the event so it can give the appropriate error message

One more unrelated fix to this PR is hiding the next update timer on streaks if there is no next event. Currently it just shows the default value from the HTML.

This is a backend patch and has no screenshots