### PR TITLE
Version check in settings

### DIFF
--- a/jams/__init__.py
+++ b/jams/__init__.py
@@ -74,7 +74,18 @@ def seed_database(app):
     with app.app_context():
         preform_seed()
 
+def get_app_version():
+    version_file = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "VERSION")
+    try:
+        with open(version_file, "r") as f:
+            return f.read().strip()
+    except FileNotFoundError:
+        return "Unknown"
+
 def prep_app(app):
+    # Store the version in the DB
+    set_config_value(ConfigType.APP_VERSION, get_app_version())
+
     # Generate HMAC secret key if it doesnt already exist:
     if not config_entry_exists(ConfigType.HMAC_SECRET_KEY):
         key = os.urandom(64)

--- a/jams/configuration.py
+++ b/jams/configuration.py
@@ -5,6 +5,7 @@ from sqlalchemy import exists
 from jams.models import db, Config
 
 class ConfigType(Enum):
+    APP_VERSION = 'APP_VERSION'
     HMAC_SECRET_KEY = 'HMAC_SECRET_KEY'
     EVENTBRITE_ENABLED = 'EVENTBRITE_ENABLED'
     EVENTBRITE_BEARER_TOKEN = 'EVENTBRITE_BEARER_TOKEN'

--- a/jams/default_config/endpoints.yaml
+++ b/jams/default_config/endpoints.yaml
@@ -154,6 +154,7 @@ groups:
     description: Handles configuration for JAMS
     read:
       get_general_config: routes.api_v1.private.general.get_general_config
+      get_latest_release: routes.api_v1.private.general.get_latest_release
     write:
       edit_general_config: routes.api_v1.private.general.edit_general_config
       recalculate_streaks: routes.api_v1.private.general.recalculate_streaks

--- a/jams/default_config/pages.yaml
+++ b/jams/default_config/pages.yaml
@@ -140,6 +140,7 @@ pages:
       - settings_jolt
     api_endpoints:
       get_general_config:
+      get_latest_release:
       edit_general_config:
       recalculate_streaks:
 

--- a/jams/routes/api_v1/private/general.py
+++ b/jams/routes/api_v1/private/general.py
@@ -26,9 +26,17 @@ def get_current_user_data():
 @api_route
 def get_general_config():
     data = {
+        ConfigType.APP_VERSION.name: get_config_value(ConfigType.APP_VERSION),
         ConfigType.TIMEZONE.name: get_config_value(ConfigType.TIMEZONE),
         ConfigType.STREAKS_ENABLED.name: get_config_value(ConfigType.STREAKS_ENABLED)
     }
+
+    return jsonify({'data': data})
+
+@bp.route('/app/latest_release', methods=['GET'])
+@api_route
+def get_latest_release():
+    data = helper.get_latest_release()
 
     return jsonify({'data': data})
 

--- a/jams/static/css/admin/settings/settings_general.css
+++ b/jams/static/css/admin/settings/settings_general.css
@@ -76,12 +76,20 @@
     font-weight: bold;
 }
 
-.release-markdown pre, .release-markdown code {
+.release-markdown pre {
     font-family: monospace;
     white-space: pre-wrap;
     word-wrap: break-word;
     margin: 0;
-    padding-left:0;
+}
+
+.release-markdown code {
+    font-family: monospace;
+}
+
+.release-markdown pre.codehilite code {
+    display: block;
+    padding-left: 10px;
 }
 
 .release-markdown ul {
@@ -92,4 +100,10 @@
 .release-markdown a {
     color: #ff9800;
     text-decoration: underline;
+}
+
+.theme-light .release-markdown pre,
+.theme-light .release-markdown pre code {
+    background-color: #f8f9fa; /* light background */
+    color: #333; /* dark text for readability */
 }

--- a/jams/static/css/admin/settings/settings_general.css
+++ b/jams/static/css/admin/settings/settings_general.css
@@ -63,3 +63,33 @@
         display: none;
     }
 }
+
+.release-markdown {
+    font-size: 14px;
+    line-height: 1.5;
+}
+
+.release-markdown h1, 
+.release-markdown h2, 
+.release-markdown h3 {
+    margin-top: 10px;
+    font-weight: bold;
+}
+
+.release-markdown pre, .release-markdown code {
+    font-family: monospace;
+    white-space: pre-wrap;
+    word-wrap: break-word;
+    margin: 0;
+    padding-left:0;
+}
+
+.release-markdown ul {
+    list-style: disc;
+    margin-left: 20px;
+}
+
+.release-markdown a {
+    color: #ff9800;
+    text-decoration: underline;
+}

--- a/jams/static/ts/admin/settings/settings_general.ts
+++ b/jams/static/ts/admin/settings/settings_general.ts
@@ -1,4 +1,4 @@
-import { editGeneralConfig, getGeneralConfig, recalculateStreaks } from "@global/endpoints";
+import { editGeneralConfig, getGeneralConfig, getLatestRelease, recalculateStreaks } from "@global/endpoints";
 import { GeneralConfig } from "@global/endpoints_interfaces";
 import { errorToast, isDefined, successToast } from "@global/helper";
 import { allTimezones } from "@global/timezones";
@@ -15,6 +15,31 @@ function checkIfConentUpdated() {
         saveButton.disabled = false
     } else {
         saveButton.disabled = true
+    }
+}
+
+async function populateVersionSection() {
+    const releaseData = await getLatestRelease()
+    const upToDateVersionBlock = document.getElementById('version-block-utd') as HTMLDivElement
+    const outOfDateVersionBlock = document.getElementById('version-block-ood') as HTMLDivElement
+
+    if (currentConfig.APP_VERSION !== releaseData.version) {
+        upToDateVersionBlock.style.display = 'none'
+        outOfDateVersionBlock.style.display = 'block'
+
+        let versionText = document.getElementById('version-text-ood')
+        versionText.innerHTML = `v${currentConfig.APP_VERSION} (out of date)`
+
+        if (releaseData.release_notes) {
+            document.getElementById('release-notes').innerHTML = releaseData.release_notes
+        }
+        (document.getElementById('release-btn') as HTMLAnchorElement).href = releaseData.url
+    } else {
+        upToDateVersionBlock.style.display = 'block'
+        outOfDateVersionBlock.style.display = 'none'
+
+        let versionText = document.getElementById('version-text-utd')
+        versionText.innerHTML = `v${currentConfig.APP_VERSION} (up to date)`
     }
 }
 
@@ -54,6 +79,7 @@ async function setupPage() {
         currentConfig = await getGeneralConfig()
     }
 
+    populateVersionSection()
     populateLocationSelect()
     populateStreaksSection()
 }

--- a/jams/static/ts/admin/settings/settings_general.ts
+++ b/jams/static/ts/admin/settings/settings_general.ts
@@ -1,6 +1,6 @@
 import { editGeneralConfig, getGeneralConfig, getLatestRelease, recalculateStreaks } from "@global/endpoints";
 import { GeneralConfig } from "@global/endpoints_interfaces";
-import { errorToast, isDefined, successToast } from "@global/helper";
+import { errorToast, isDefined, isNullEmptyOrSpaces, successToast } from "@global/helper";
 import { allTimezones } from "@global/timezones";
 
 let currentConfig:Partial<GeneralConfig>|null=null
@@ -23,12 +23,23 @@ async function populateVersionSection() {
     const upToDateVersionBlock = document.getElementById('version-block-utd') as HTMLDivElement
     const outOfDateVersionBlock = document.getElementById('version-block-ood') as HTMLDivElement
 
+    const upToDateVersionText = document.getElementById('version-text-utd') as HTMLSpanElement
+    const outOfDateVersionText = document.getElementById('version-text-ood') as HTMLSpanElement
+
+    if ((releaseData === null || releaseData === undefined) || isNullEmptyOrSpaces(releaseData.version)) {
+        upToDateVersionBlock.style.display = 'block'
+        upToDateVersionText.innerHTML = `v${currentConfig.APP_VERSION} (Cannot connect to GitHub)`
+        const parent = upToDateVersionText.parentElement
+        const icon = parent.querySelector('i')
+        icon.className = 'ti ti-cloud-off text-danger'
+        return
+    }
+
     if (currentConfig.APP_VERSION !== releaseData.version) {
         upToDateVersionBlock.style.display = 'none'
         outOfDateVersionBlock.style.display = 'block'
 
-        let versionText = document.getElementById('version-text-ood')
-        versionText.innerHTML = `v${currentConfig.APP_VERSION} (out of date)`
+        outOfDateVersionText.innerHTML = `v${currentConfig.APP_VERSION} (out of date)`
 
         if (releaseData.release_notes) {
             document.getElementById('release-notes').innerHTML = releaseData.release_notes
@@ -38,8 +49,7 @@ async function populateVersionSection() {
         upToDateVersionBlock.style.display = 'block'
         outOfDateVersionBlock.style.display = 'none'
 
-        let versionText = document.getElementById('version-text-utd')
-        versionText.innerHTML = `v${currentConfig.APP_VERSION} (up to date)`
+        upToDateVersionText.innerHTML = `v${currentConfig.APP_VERSION} (up to date)`
     }
 }
 

--- a/jams/static/ts/global/endpoints.ts
+++ b/jams/static/ts/global/endpoints.ts
@@ -38,7 +38,8 @@ import {
     sessionSettings,
     JOLTStatus,
     JOLTConfig,
-    StreadData
+    StreadData,
+    GitHubReleaseResponse
 } from "@global/endpoints_interfaces";
 import { formatDate } from "./helper";
 
@@ -2260,6 +2261,22 @@ export function getGeneralConfig():Promise<GeneralConfig> {
     return new Promise((resolve, reject) => {
         $.ajax({
             url: `${baseURL}/app/config`,
+            type: 'GET',
+            success: function (response) {
+                resolve(response.data)
+            },
+            error: function (error) {
+                console.log('Error fetching data:', error);
+                reject(false)
+            }
+        });
+    });
+}
+
+export function getLatestRelease():Promise<GitHubReleaseResponse> {
+    return new Promise((resolve, reject) => {
+        $.ajax({
+            url: `${baseURL}/app/latest_release`,
             type: 'GET',
             success: function (response) {
                 resolve(response.data)

--- a/jams/static/ts/global/endpoints_interfaces.ts
+++ b/jams/static/ts/global/endpoints_interfaces.ts
@@ -317,6 +317,7 @@ export interface AttendeeSignup {
 }
 
 export interface GeneralConfig {
+    APP_VERSION?:string
     TIMEZONE?:string
     STREAKS_ENABLED?:boolean
 }
@@ -351,4 +352,10 @@ export interface StreadData {
     longest_streak:number
     freezes:number
     total_attended:number
+}
+
+export interface GitHubReleaseResponse {
+    version:string
+    release_notes:string
+    url:string
 }

--- a/jams/templates/_layout.html
+++ b/jams/templates/_layout.html
@@ -17,7 +17,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 </head>
 
-<body>
+<body class="theme-dark">
     <div id="nav-container"></div>
     <div class="page">
         <div class="page-wrapper">

--- a/jams/templates/private/admin/settings/settings-general.html
+++ b/jams/templates/private/admin/settings/settings-general.html
@@ -6,7 +6,48 @@
 
 {% block settings_content %}
 
-<div id="eventbrite-settings-content" class="settings-content-container">
+<div id="general-settings-content" class="settings-content-container">
+    <div class="card">
+        <div class="card-body">
+            <!-- Current Version -->
+            <div id="version-block-utd" style="display: none;">
+                <h3>Current Version</h3>
+                <div class="d-flex justify-content-between align-items-center mb-3">
+                    <span>
+                        <i class="ti ti-circle-check text-success"></i>
+                        <span id="version-text-utd" class="ms-2"></span>
+                    </span>
+                </div>
+            </div>
+    
+            <!-- Update Section (Hidden Initially) -->
+            <div id="version-block-ood" style="display: none;">
+                <h3 class="mt-3">New Version Available</h3>
+                <div class="d-flex justify-content-between align-items-center mb-3">
+                    <span>
+                        <i class="ti ti-alert-circle text-warning"></i>
+                        <span id="version-text-ood" class="ms-2"></span>
+                    </span>
+                    <button class="btn btn-outline-warning" data-bs-toggle="collapse" data-bs-target="#releaseNotesSection">
+                        <i class="ti ti-arrow-down"></i>
+                        <span class="btn-text ms-2">View Release Notes</span>
+                    </button>
+                </div>
+    
+                <!-- Release Notes Accordion -->
+                <div id="releaseNotesSection" class="collapse">
+                    <div class="card card-body">
+                        <p id="release-notes" class="release-markdown">Fetching release notes...</p>
+                        <a id="release-btn" href="#" target="_blank" class="btn btn-outline-warning mt-2">
+                            <i class="ti ti-external-link"></i>
+                            <span class="ms-2">View on GitHub</span>
+                        </a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
     <p class="mb-3">Here you can configure general settings for JAMS. More advanced options will have their own setting page on the side bar</p>
 
     <div class="table-responsive">

--- a/jams/util/helper.py
+++ b/jams/util/helper.py
@@ -843,7 +843,7 @@ def update_scheduled_streak_update_task_date(event, date):
     task_scheduler.modify_task(task_name=task_name, param_dict=params_dict)
 
 def get_latest_release():
-    url = f"https://api.github.com/repos/jdplays/jams/releases/latest"
+    url = "https://api.github.com/repos/jdplays/jams/releases/latest"
     headers = {"Accept": "application/vnd.github.v3+json"}
     try:
         response = requests.get(url, headers=headers, timeout=5)

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ requests
 Authlib
 pytz
 websockets==13.0
+markdown


### PR DESCRIPTION
This PR adds a version checker to the general settings page. It displays the current JAMS version and fetches the latest release from GitHub. If a newer version is available, it displays a warning with the release notes and a link to the GitHub release.

Screenshots:
Up to date
![image](https://github.com/user-attachments/assets/4efee949-ca43-4f15-8ede-c76fd2fbe296)

Out of date
![image](https://github.com/user-attachments/assets/ec29eead-933e-4c71-9792-155f1be3f8df)


Connection Error
![image](https://github.com/user-attachments/assets/a98dc278-9385-4a91-b3f1-b77bf7df1e7b)


