### PR TITLE
Quality of Life changes

### DIFF
--- a/jams/configuration.py
+++ b/jams/configuration.py
@@ -29,6 +29,7 @@ class ConfigType(Enum):
     JOLT_ENABLED = 'JOLT_ENABLED',
     JOLT_API_KEY_ID = 'JOLT_API_KEY_ID'
     STREAKS_ENABLED = 'STREAKS_ENABLED'
+    EVENT_PREFIX_FILTER = 'EVENT_PREFIX_FILTER'
 
 
 def config_entry_exists(key:Union[str, ConfigType]):

--- a/jams/default_config/endpoints.yaml
+++ b/jams/default_config/endpoints.yaml
@@ -55,6 +55,7 @@ groups:
     read:
       get_next_event_id: routes.api_v1.public.general.get_next_event
       get_event: routes.api_v1.private.admin.get_event
+      get_event_metadata: routes.api_v1.private.admin.get_event_metadata
       get_event_field: routes.api_v1.private.admin.get_event_field
       get_events: routes.api_v1.private.admin.get_events
       get_events_field: routes.api_v1.private.admin.get_events_field

--- a/jams/default_config/pages.yaml
+++ b/jams/default_config/pages.yaml
@@ -356,7 +356,7 @@ pages:
     public: true
     api_endpoints:
       get_event_field:
-        allowed_fields: id, name, date
+        allowed_fields: id, name, filtered_name, date
 
         
   public_schedule:

--- a/jams/default_config/pages.yaml
+++ b/jams/default_config/pages.yaml
@@ -189,6 +189,7 @@ pages:
       get_events_field:
         allowed_fields: id, name
       get_event:
+      get_event_metadata:
       # Workshops
       get_workshops:
       get_difficulty_levels:

--- a/jams/models/event.py
+++ b/jams/models/event.py
@@ -20,6 +20,11 @@ class Event(db.Model):
     external_id = Column(String(), nullable=True)
     external_url = Column(String(), nullable=True)
 
+    @property
+    def filtered_name(self):
+        from jams.util import helper
+        return helper.remove_event_name_prefix(self.name)
+
     def __init__(self, name, description, date, start_date_time, end_date_time, capacity, password, active=True, external=False, external_id=None, external_url = None):
         self.name = name
         self.description = description
@@ -48,6 +53,7 @@ class Event(db.Model):
         return {
             'id': self.id,
             'name': self.name,
+            'filtered_name': self.filtered_name,
             'description': self.description,
             'date': str(date),
             'start_date_time': str(start_datetime),

--- a/jams/models/management.py
+++ b/jams/models/management.py
@@ -47,6 +47,7 @@ class Workshop(db.Model):
     publicly_visible = Column(Boolean, nullable=False, default=True, server_default='true')
     min_volunteers = Column(Integer(), nullable=True)
     capacity = Column(Integer(), nullable=True)
+    overflow = Column(Boolean, nullable=False, default=False, server_default='false')
 
     difficulty = relationship('DifficultyLevel', backref='workshops')
     workshop_type = relationship('WorkshopType', backref='workshops')
@@ -58,7 +59,7 @@ class Workshop(db.Model):
         return True
 
     # Requires name and description to be passed
-    def __init__(self, name, description, difficulty_id=None, active=True, volunteer_signup=True, attendee_registration=True, publicly_visible=True, min_volunteers=0, capacity=0, workshop_type_id=None):
+    def __init__(self, name, description, difficulty_id=None, active=True, volunteer_signup=True, attendee_registration=True, publicly_visible=True, min_volunteers=0, capacity=0, overflow=False, workshop_type_id=None):
         self.name = name
         self.description = description
         self.difficulty_id = difficulty_id
@@ -68,6 +69,7 @@ class Workshop(db.Model):
         self.publicly_visible = publicly_visible
         self.min_volunteers = min_volunteers
         self.capacity = capacity
+        self.overflow = overflow
         
         if not workshop_type_id:
             workshop_type = WorkshopType.query.filter_by(name='Standard Workshop').first()
@@ -116,6 +118,7 @@ class Workshop(db.Model):
         if not self.attendee_registration:
             self.capacity = None
             self.difficulty_id = None
+            self.overflow = False
 
     def to_dict(self):
         return {
@@ -130,7 +133,8 @@ class Workshop(db.Model):
             'attendee_registration': self.attendee_registration,
             'publicly_visible': self.publicly_visible,
             'min_volunteers': self.min_volunteers,
-            'capacity': self.capacity
+            'capacity': self.capacity,
+            'overflow': self.overflow
         }
     
 class DifficultyLevel(db.Model):

--- a/jams/routes/api_v1/private/admin.py
+++ b/jams/routes/api_v1/private/admin.py
@@ -298,6 +298,12 @@ def get_events_field(field):
     data = helper.filter_model_by_query_and_properties(Event, request.args, field)
     return jsonify(data)
 
+@bp.route('/events/<int:event_id>/metadata', methods=['GET'])
+@api_route
+def get_event_metadata(event_id):
+    event = Event.query.filter_by(id=event_id).first_or_404()
+    return jsonify({'data': event.get_metadata()})
+
 
 @bp.route('/events/<int:event_id>', methods=['GET'])
 @api_route

--- a/jams/routes/api_v1/private/general.py
+++ b/jams/routes/api_v1/private/general.py
@@ -28,7 +28,8 @@ def get_general_config():
     data = {
         ConfigType.APP_VERSION.name: get_config_value(ConfigType.APP_VERSION),
         ConfigType.TIMEZONE.name: get_config_value(ConfigType.TIMEZONE),
-        ConfigType.STREAKS_ENABLED.name: get_config_value(ConfigType.STREAKS_ENABLED)
+        ConfigType.STREAKS_ENABLED.name: get_config_value(ConfigType.STREAKS_ENABLED),
+        ConfigType.EVENT_PREFIX_FILTER.name: get_config_value(ConfigType.EVENT_PREFIX_FILTER)
     }
 
     return jsonify({'data': data})
@@ -54,10 +55,14 @@ def edit_general_config():
     streaks_enabled = data.get(ConfigType.STREAKS_ENABLED.name)
     if streaks_enabled is not None:
         set_config_value(ConfigType.STREAKS_ENABLED, streaks_enabled)
+
+    event_prefix_filter = data.get(ConfigType.EVENT_PREFIX_FILTER.name)
+    set_config_value(ConfigType.EVENT_PREFIX_FILTER, event_prefix_filter)
     
     config = {
         ConfigType.TIMEZONE.name: get_config_value(ConfigType.TIMEZONE),
-        ConfigType.STREAKS_ENABLED.name: get_config_value(ConfigType.STREAKS_ENABLED)
+        ConfigType.STREAKS_ENABLED.name: get_config_value(ConfigType.STREAKS_ENABLED),
+        ConfigType.EVENT_PREFIX_FILTER.name: get_config_value(ConfigType.EVENT_PREFIX_FILTER)
     } 
 
     return jsonify({'data': config})

--- a/jams/routes/api_v1/private/management.py
+++ b/jams/routes/api_v1/private/management.py
@@ -57,13 +57,14 @@ def add_workshop():
     difficulty_id = data.get('difficulty_id')
     min_volunteers = data.get('min_volunteers')
     capacity = data.get('capacity')
+    overflow = data.get('overflow')
     workshop_type_id = data.get('workshop_type_id')
     
 
     if not name or not description or not difficulty_id or difficulty_id == '-1':
         abort(400, description="No 'name' or 'description' or 'difficulty_id' provided")
 
-    new_workshop = Workshop(name=name, description=description, min_volunteers=min_volunteers, difficulty_id=difficulty_id, capacity=capacity, workshop_type_id=workshop_type_id)
+    new_workshop = Workshop(name=name, description=description, min_volunteers=min_volunteers, difficulty_id=difficulty_id, capacity=capacity, overflow=overflow, workshop_type_id=workshop_type_id)
     db.session.add(new_workshop)
     db.session.commit()
 
@@ -365,11 +366,12 @@ def add_timeslot():
     start = data.get('start')
     end = data.get('end')
     is_break = data.get('is_break')
+    capacity_suggestion = data.get('capacity_suggestion')
 
     if not name:
         abort(400, description="No 'name' provided")
 
-    new_timeslot = Timeslot(name=name, start=start, end=end, is_break=is_break)
+    new_timeslot = Timeslot(name=name, start=start, end=end, is_break=is_break, capacity_suggestion=capacity_suggestion)
     db.session.add(new_timeslot)
     db.session.commit()
 

--- a/jams/static/css/general/global.css
+++ b/jams/static/css/general/global.css
@@ -83,3 +83,8 @@
       display: none;
   }
 }
+
+.custom-tooltip {
+  position: absolute;
+  width: fit-content;
+}

--- a/jams/static/css/general/schedule_grid.css
+++ b/jams/static/css/general/schedule_grid.css
@@ -100,6 +100,8 @@
 .header-text-secondary {
     font-weight: normal;
     font-size: 12;
+    margin-top: 0px;
+    margin-bottom: 0px;
 }
 
 .session-block {

--- a/jams/static/css/general/schedule_grid.css
+++ b/jams/static/css/general/schedule_grid.css
@@ -97,7 +97,7 @@
     text-align: center;
 }
 
-.timeslot-range {
+.header-text-secondary {
     font-weight: normal;
     font-size: 12;
 }

--- a/jams/static/ts/admin/settings/settings_general.ts
+++ b/jams/static/ts/admin/settings/settings_general.ts
@@ -10,8 +10,9 @@ function checkIfContentUpdated() {
 
     const locationSelect = document.getElementById('loc-select') as HTMLSelectElement
     const streaksSwitch = document.getElementById('toggle-streaks-switch') as HTMLInputElement
+    const eventPrefixFilterInput = document.getElementById('prefix-filter-input') as HTMLInputElement
 
-    if (locationSelect.value !== currentConfig.TIMEZONE || streaksSwitch.checked !== currentConfig.STREAKS_ENABLED) {
+    if (locationSelect.value !== currentConfig.TIMEZONE || streaksSwitch.checked !== currentConfig.STREAKS_ENABLED || (eventPrefixFilterInput.value ?? '') !== (currentConfig.EVENT_PREFIX_FILTER ?? '')) {
         saveButton.disabled = false
     } else {
         saveButton.disabled = true
@@ -78,10 +79,11 @@ function populateLocationSelect() {
 function populateStreaksSection() {
     const streaksSwitch = document.getElementById('toggle-streaks-switch') as HTMLInputElement
     const refreshButton = document.getElementById('streak-refresh-button') as HTMLButtonElement
+    const eventPrefixFilterInput = document.getElementById('prefix-filter-input') as HTMLInputElement
 
     streaksSwitch.checked = currentConfig.STREAKS_ENABLED
-
     refreshButton.disabled = !currentConfig.STREAKS_ENABLED
+    eventPrefixFilterInput.value = currentConfig.EVENT_PREFIX_FILTER
 }
 
 async function setupPage() {
@@ -97,10 +99,12 @@ async function setupPage() {
 function generalConfigSaveOnClick() {
     const locationSelect = document.getElementById('loc-select') as HTMLSelectElement
     const streaksSwitch = document.getElementById('toggle-streaks-switch') as HTMLInputElement
+    const eventPrefixFilterInput = document.getElementById('prefix-filter-input') as HTMLInputElement
 
     const data:GeneralConfig = {
         TIMEZONE: locationSelect.value,
-        STREAKS_ENABLED: streaksSwitch.checked
+        STREAKS_ENABLED: streaksSwitch.checked,
+        EVENT_PREFIX_FILTER: eventPrefixFilterInput.value
     }
 
     editGeneralConfig(data).then((response) => {

--- a/jams/static/ts/global/endpoints.ts
+++ b/jams/static/ts/global/endpoints.ts
@@ -39,7 +39,8 @@ import {
     JOLTStatus,
     JOLTConfig,
     StreadData,
-    GitHubReleaseResponse
+    GitHubReleaseResponse,
+    EventMetadata
 } from "@global/endpoints_interfaces";
 import { formatDate } from "./helper";
 
@@ -918,6 +919,22 @@ export function getEventField(eventID:number, field:string):Promise<Partial<Even
     return new Promise((resolve, reject) => {
         $.ajax({
             url: `${baseURL}/events/${eventID}/${field}`,
+            type: 'GET',
+            success: function(response) {
+                resolve(response);   
+            },
+            error: function(error) {
+                console.log('Error fetching data:', error);
+                reject(error);
+            }
+        });
+    });
+}
+
+export function getEventMetadata(eventID:number):Promise<ApiResponse<EventMetadata>> {
+    return new Promise((resolve, reject) => {
+        $.ajax({
+            url: `${baseURL}/events/${eventID}/metadata`,
             type: 'GET',
             success: function(response) {
                 resolve(response);   

--- a/jams/static/ts/global/endpoints_interfaces.ts
+++ b/jams/static/ts/global/endpoints_interfaces.ts
@@ -85,6 +85,7 @@ export interface WorkshopType {
 export interface Event {
     id:number
     name:string
+    filtered_name:string
     description:string
     date:string
     start_date_time:string
@@ -324,6 +325,7 @@ export interface GeneralConfig {
     APP_VERSION?:string
     TIMEZONE?:string
     STREAKS_ENABLED?:boolean
+    EVENT_PREFIX_FILTER?:string
 }
 
 export interface FireListEntry {

--- a/jams/static/ts/global/endpoints_interfaces.ts
+++ b/jams/static/ts/global/endpoints_interfaces.ts
@@ -30,6 +30,7 @@ export interface Timeslot {
     range:string
     is_break:boolean
     active:boolean
+    capacity_suggestion:boolean
 }
 
 export interface Workshop {
@@ -45,6 +46,7 @@ export interface Workshop {
     publicly_visible:boolean
     min_volunteers:number
     capacity:number
+    overflow:boolean
 }
 
 export interface Session {
@@ -360,4 +362,9 @@ export interface GitHubReleaseResponse {
     version:string
     release_notes:string
     url:string
+}
+
+export interface EventMetadata {
+    id:number
+    attendee_count:number
 }

--- a/jams/static/ts/global/event_details.ts
+++ b/jams/static/ts/global/event_details.ts
@@ -99,10 +99,10 @@ export class EventDetails {
         const eventInfoText = document.createElement('p')
     
         if (this.eventId && this.eventId !== -1) {
-            let eventName = await getEventField(this.eventId, 'name')
+            let eventName = await getEventField(this.eventId, 'filtered_name')
             let eventDate = await getEventField(this.eventId, 'date')
             const date = (eventDate.date)
-            eventInfoText.innerHTML = `<strong>${eventName.name}</strong> - ${formatDateToShort(date, {includeTime:false})}`
+            eventInfoText.innerHTML = `<strong>${eventName.filtered_name}</strong> - ${formatDateToShort(date, {includeTime:false})}`
 
             for (const element of this.options.eventDependentElements) {
                 if (element) {

--- a/jams/static/ts/global/interfaces.ts
+++ b/jams/static/ts/global/interfaces.ts
@@ -54,3 +54,8 @@ export interface dateTimeFormatterOptions {
     includeTime?:boolean
     includeSeconds?:boolean
 }
+
+export interface ScheduleGridTimeslotCapacity {
+    capacity?:number
+    overflow?:number
+}

--- a/jams/static/ts/global/schedule_grid.ts
+++ b/jams/static/ts/global/schedule_grid.ts
@@ -21,12 +21,13 @@ import {
     getAttendeesSignups,
     getWorkshopField,
     recalculateSessionCapacity,
-    updateSessionSettings
+    updateSessionSettings,
+    getEventMetadata
 } from '@global/endpoints'
-import { DifficultyLevel, EventLocation, EventTimeslot, Location, Session, sessionSettings, Timeslot, User, VolunteerSignup, WorkshopType } from '@global/endpoints_interfaces'
+import { DifficultyLevel, EventLocation, EventMetadata, EventTimeslot, Location, Session, sessionSettings, Timeslot, User, VolunteerSignup, Workshop, WorkshopType } from '@global/endpoints_interfaces'
 import {buildQueryString, emptyElement, allowDrop, waitForTransitionEnd, debounce, successToast, errorToast, buildUserAvatar, preloadUsersInfoMap, animateElement, isTouchDevice, hexToRgba, isNullEmptyOrSpaces} from '@global/helper'
 import {WorkshopCard, WorkshopCardOptions} from '@global/workshop_card'
-import { QueryStringData } from './interfaces'
+import { QueryStringData, ScheduleGridTimeslotCapacity } from './interfaces'
 
 type Icons = {[key: string]: any}
 
@@ -74,13 +75,17 @@ export class ScheduleGrid {
     private attendeeSignupCountsMap:Record<number, number> = {}
     private usersInfoMap:Record<number, Partial<User>> = {}
     private sessionsMap:Record<number, Session> = {}
+    private timeslotCapacityMap:Record<number, ScheduleGridTimeslotCapacity> = {}
 
     private difficultyLevels:DifficultyLevel[]
     private workshopTypes:WorkshopType[]
+    private workshopsMap:Record<number, Workshop> = {}
 
     public currentDragType:string
     public scheduleValid:boolean
     public fatalError:boolean
+
+    private eventMetadata:EventMetadata;
 
 
     constructor(scheduleContainerId:string, options:ScheduleGridOptions = {}) {
@@ -173,6 +178,9 @@ export class ScheduleGrid {
 
     // Get the grid ready
     async init(reInit:boolean=false) {
+        if (this.options.edit) {
+            this.eventMetadata = (await getEventMetadata(this.options.eventId)).data
+        }
 
         if (isTouchDevice() && this.options.edit) {
             // Editing is currently not available on touch devices due to drag and drop not working well on them
@@ -227,7 +235,7 @@ export class ScheduleGrid {
             }
         }
 
-        if (this.options.volunteerSignup || this.options.edit) {
+        if (this.options.volunteerSignup) {
             // Preload users Info Map
             if (Object.keys(this.options.userInfoMap).length <= 0) {
                 this.usersInfoMap = await preloadUsersInfoMap()
@@ -598,9 +606,33 @@ export class ScheduleGrid {
             timeslotContainer.appendChild(timeslotName)
 
             let timeslotRange = document.createElement('p')
-            timeslotRange.classList.add('header-row', 'timeslot-range')
+            timeslotRange.classList.add('header-row', 'header-text-secondary')
             timeslotRange.innerText = timeslot.range
             timeslotContainer.appendChild(timeslotRange)
+
+            if (this.options.edit && timeslot.capacity_suggestion) {
+                let capacityVisualiserContainer = document.createElement('span')
+                capacityVisualiserContainer.classList.add('d-flex')
+                capacityVisualiserContainer.style.gap = '5px'
+                capacityVisualiserContainer.title = 'Timeslot capacity (+ overflow slots) / 75% of attendees'
+
+                let capacity = document.createElement('p')
+                capacity.id = `capacity-${timeslot.id}`
+                capacity.classList.add('header-row', 'header-text-secondary')
+                capacityVisualiserContainer.appendChild(capacity)
+                
+                let overflow = document.createElement('p')
+                overflow.id = `overflow-${timeslot.id}`
+                overflow.classList.add('header-row', 'header-text-secondary')
+                capacityVisualiserContainer.appendChild(overflow)
+
+                let totalCap = document.createElement('p')
+                totalCap.id = `total-cap-${timeslot.id}`
+                totalCap.classList.add('header-row', 'header-text-secondary')
+                capacityVisualiserContainer.appendChild(totalCap)
+                
+                timeslotContainer.appendChild(capacityVisualiserContainer)
+            }
 
             let emptyTimeslotRow = document.createElement('div')
             emptyTimeslotRow.classList.add('header-row', 'header-row-spacer')
@@ -1089,6 +1121,11 @@ export class ScheduleGrid {
 
             // Iterate over each workshop to be added and trigger an animation to set the workshop
             for (const workshop of workshopsToAdd) {
+                // Add the workshop to the workshops map
+                if (!this.workshopsMap[workshop.id]) {
+                    this.workshopsMap[workshop.id] = workshop
+                }
+
                 let sessionBlock = document.getElementById(`session-${workshop.event_location_id}-${workshop.event_timeslot_id}`)
                 if (!sessionBlock) {
                     continue
@@ -1241,6 +1278,73 @@ export class ScheduleGrid {
                     sessionBlock.removeEventListener('drop', this.handleDropWithContext)
                     sessionBlock.addEventListener('drop', this.handleDropWithContext)
                     sessionBlock.addEventListener('dragover', allowDrop);
+                }
+
+                // Remove old workshops from the workshops map
+                if (this.workshopsMap[workshop.workshop_id]) {
+                    delete this.workshopsMap[workshop.workshop_id]
+                }
+            }
+        }
+
+        // Add each session's capacity to the capacity map
+        if (this.options.edit) {
+            this.timeslotCapacityMap = {}
+            for (const session of sessions) {    
+                if (!session.has_workshop) {
+                    continue
+                }
+
+                const workshop = this.workshopsMap[session.workshop_id]
+                if (!workshop) {
+                    continue
+                }
+
+                const realTimeslotId = this.getTimeslotIdfromEventTimeslotId(session.event_timeslot_id)
+                if (!this.timeslotCapacityMap[realTimeslotId]) {
+                    let timeslotCapacity:ScheduleGridTimeslotCapacity = {
+                        capacity: 0,
+                        overflow: 0
+                    }
+                    this.timeslotCapacityMap[realTimeslotId] = timeslotCapacity
+                }
+
+                if (realTimeslotId === 6) {
+                }
+
+                if (workshop.overflow) {
+                    this.timeslotCapacityMap[realTimeslotId].overflow += session.capacity
+                } else {
+                    this.timeslotCapacityMap[realTimeslotId].capacity += session.capacity
+                }
+            }
+
+            // Update capacity visualiser
+            for (const [timeslotId, timeslotCapacity] of Object.entries(this.timeslotCapacityMap)) {
+                const capacityText = document.getElementById(`capacity-${timeslotId}`)
+                const overflowText = document.getElementById(`overflow-${timeslotId}`)
+                const totalCapacityText = document.getElementById(`total-cap-${timeslotId}`)
+
+                if (!capacityText || !overflowText || !totalCapacityText) {
+                    continue
+                }
+
+                capacityText.innerHTML = String(timeslotCapacity.capacity)
+                overflowText.innerHTML = `(+${timeslotCapacity.overflow})`
+                const totalCapacity = Math.ceil(this.eventMetadata.attendee_count * 0.75)
+                totalCapacityText.innerHTML = `/${totalCapacity}`
+
+                // Style the text
+                const combinedCapacity = timeslotCapacity.capacity + timeslotCapacity.overflow
+                if (combinedCapacity >= totalCapacity) {
+                    capacityText.classList.remove('text-yellow', 'text-danger')
+                    capacityText.classList.add('text-success')
+                } else if (combinedCapacity <= (totalCapacity) && combinedCapacity > (totalCapacity * 0.5)) {
+                    capacityText.classList.remove('text-success', 'text-danger')
+                    capacityText.classList.add('text-yellow')
+                } else if (combinedCapacity <= (totalCapacity * 0.5)) {
+                    capacityText.classList.remove('text-yellow', 'text-success')
+                    capacityText.classList.add('text-danger')
                 }
             }
         }
@@ -1608,6 +1712,10 @@ export class ScheduleGrid {
                 scheduleGrid.updateSchedule()
             }
         }
+    }
+
+    getTimeslotIdfromEventTimeslotId(eventTimeslotId:number):number {
+        return this.eventTimeslots.find(ts => ts.id === eventTimeslotId).timeslot_id
     }
 }
 

--- a/jams/static/ts/global/tooltips.ts
+++ b/jams/static/ts/global/tooltips.ts
@@ -1,0 +1,131 @@
+import { Role, User } from "./endpoints_interfaces";
+import { buildRoleBadge, buildUserAvatar } from "./helper";
+
+function buildUserTooltipItem(user:Partial<User>, rolesMap:Record<number, Role>|null=null) {
+    const itemDiv = document.createElement('div')
+    itemDiv.classList.add('row')
+
+    const avatar = buildUserAvatar(user)
+    
+    const tmpRolesContainer = document.createElement('div')
+    if (rolesMap) {
+        if (user.badge_text) {
+            const tag = document.createElement('span')
+            tag.classList.add('tag-with-indicator')
+            tag.style.width = 'fit-content'
+            tag.style.borderRadius = '90px'
+            tag.style.cursor = 'pointer'
+            
+            const text = document.createElement('span')
+            text.innerHTML = user.badge_text
+            tag.appendChild(text)
+
+            if (user.badge_icon) {
+                const icon = document.createElement('i')
+                icon.classList.add('ti', `ti-${user.badge_icon}`, 'ms-2')
+                icon.style.color = 'rgb(255, 215, 0)'
+                tag.appendChild(icon)
+            }
+
+            tmpRolesContainer.appendChild(tag)
+        } else {
+            const userRoles = user.role_ids
+                .map(roleId => rolesMap[roleId])
+                .filter(role => role !== undefined)
+                .sort((a, b) => a.priority - b.priority)
+            
+                const badge = buildRoleBadge(userRoles[0], null, true)
+                tmpRolesContainer.appendChild(badge)
+        }
+    }
+
+    const colAvatar = document.createElement("div");
+    colAvatar.classList.add("col-auto");
+    colAvatar.appendChild(avatar);
+
+    const colMain = document.createElement("div");
+    colMain.classList.add("col");
+
+    const textTruncate = document.createElement("div");
+    textTruncate.classList.add("text-truncate");
+    textTruncate.textContent = user.display_name;
+
+    const rolesContainer = document.createElement("div");
+    rolesContainer.id = "user-roles-container";
+    rolesContainer.classList.add("d-flex", "flex-wrap", "mb-2");
+    rolesContainer.innerHTML = tmpRolesContainer.innerHTML; // Since tmpRolesContainer is existing HTML
+
+    colMain.appendChild(textTruncate);
+    colMain.appendChild(rolesContainer);
+
+    const colIcon = document.createElement("div");
+    colIcon.classList.add("col-auto", "d-flex", "align-items-center");
+
+    const icon = document.createElement("i");
+    icon.classList.add("ti", "ti-chevron-right", "text-muted");
+
+    colIcon.appendChild(icon);
+
+    // Append all to itemDiv
+    itemDiv.appendChild(colAvatar);
+    itemDiv.appendChild(colMain);
+    itemDiv.appendChild(colIcon);
+
+    return itemDiv
+}
+
+export function buildUserTooltip(user:Partial<User>, rolesMap:Record<number, Role>|null=null) {
+    const tooltipDiv = document.createElement("div");
+    const userItem = buildUserTooltipItem(user, rolesMap)
+
+    // Create the anchor element
+    const link = document.createElement("a");
+    link.href = `/private/users/${user.id}`;
+    link.classList.add("text-decoration-none");
+
+    // Create the card elements
+    const card = document.createElement("div");
+    card.classList.add("card", "card-sm");
+
+    const cardBody = document.createElement("div");
+    cardBody.classList.add("card-body");
+
+    // Append the userItem inside cardBody
+    cardBody.appendChild(userItem);
+
+    // Build the structure
+    card.appendChild(cardBody);
+    link.appendChild(card);
+    tooltipDiv.appendChild(link)
+
+    return tooltipDiv
+}
+
+export function addTooltipToElement(tooltipElement:HTMLElement, target:HTMLElement, timeout:number=5000, left:number=100) {
+    tooltipElement.classList.add("custom-tooltip");
+
+    // Position the tooltip near the target element
+    const rect = target.getBoundingClientRect()
+    tooltipElement.style.top = `${window.scrollY + rect.top - 30}px`
+    tooltipElement.style.left = `${window.scrollX + rect.left + left}px`
+
+    // Add tooltip to the DOM
+    document.body.appendChild(tooltipElement)
+    hideTooltip(tooltipElement, timeout)
+}
+
+export function hideTooltip(tooltipElement:HTMLElement|Element, timeout:number=0) {
+    setTimeout(() => {
+        if (tooltipElement) {
+            tooltipElement.remove()
+        }
+    }, timeout)
+}
+
+export function hideAllTooltips() {
+    const tooltips = document.querySelectorAll('.custom-tooltip')
+
+    tooltips.forEach(tt => {
+        hideTooltip(tt)
+    })
+}

--- a/jams/static/ts/management/events/events.ts
+++ b/jams/static/ts/management/events/events.ts
@@ -98,7 +98,8 @@ function initialiseAgGrid() {
         },
         columnDefs: [
             {
-                field: 'name',
+                field: 'filtered_name',
+                headerName: 'Name',
                 cellRenderer: (params:any) => {
                     if (!params.data) {
                       return 'Loading...'

--- a/jams/static/ts/management/locations_timeslots.ts
+++ b/jams/static/ts/management/locations_timeslots.ts
@@ -167,7 +167,8 @@ async function addTimeslotOnClick() {
         'name': (document.getElementById('add-timeslot-name') as HTMLInputElement).value,
         'start': (document.getElementById('add-timeslot-start-time') as HTMLInputElement).value,
         'end': (document.getElementById('add-timeslot-end-time') as HTMLInputElement).value,
-        'is_break': (document.getElementById('add-timeslot-is-break') as HTMLInputElement).checked
+        'is_break': (document.getElementById('add-timeslot-is-break') as HTMLInputElement).checked,
+        'capacity_suggestion': (document.getElementById('add-timeslot-capacity-suggestion') as HTMLInputElement).checked
     }
 
     const response = await addTimeslot(data)
@@ -186,7 +187,8 @@ async function editTimeslotOnClick() {
         'name': (document.getElementById('edit-timeslot-name') as HTMLInputElement).value,
         'start': (document.getElementById('edit-timeslot-start-time') as HTMLInputElement).value,
         'end': (document.getElementById('edit-timeslot-end-time') as HTMLInputElement).value,
-        'is_break': (document.getElementById('edit-timeslot-is-break') as HTMLInputElement).checked
+        'is_break': (document.getElementById('edit-timeslot-is-break') as HTMLInputElement).checked,
+        'capacity_suggestion': (document.getElementById('edit-timeslot-capacity-suggestion') as HTMLInputElement).checked
     }
 
     const response = await editTimeslot(timeslotID, data)
@@ -207,12 +209,14 @@ async function prepEditTimeslotForm(timeslotId:number) {
     const startInput = document.getElementById('edit-timeslot-start-time') as HTMLInputElement
     const endInput = document.getElementById('edit-timeslot-end-time') as HTMLInputElement
     const isBreakInput = document.getElementById('edit-timeslot-is-break') as HTMLInputElement
+    const showCapacitySuggestion = document.getElementById('edit-timeslot-capacity-suggestion') as HTMLInputElement
 
     hiddenIdInput.value = String(timeslotId)
     nameInput.value = timeslot.name
     startInput.value = timeslot.start
     endInput.value = timeslot.end
     isBreakInput.checked = timeslot.is_break
+    showCapacitySuggestion.checked = timeslot.capacity_suggestion
 }
 
 function initialiseTimeslotsAgGrid() {
@@ -243,6 +247,7 @@ function initialiseTimeslotsAgGrid() {
                 },
                 flex: 1, minWidth: 100},
             {field: 'is_break', headerName: 'Break', cellRenderer: 'agCheckboxCellRenderer', flex: 1, minWidth: 50},
+            {field: 'capacity_suggestion', headerName: 'Capacity Suggestion', cellRenderer: 'agCheckboxCellRenderer', flex: 1, minWidth: 50},
             {
                 field: 'options', cellRenderer: (params:any) => {
                     return buildActionButtonsForModel(params.data.id, params.data.active, archiveTimeslotOnClick, activateTimeslotOnClick, 'edit-timeslot-modal', prepEditTimeslotForm)

--- a/jams/static/ts/management/workshops/add_workshop.ts
+++ b/jams/static/ts/management/workshops/add_workshop.ts
@@ -66,6 +66,7 @@ function addWorkshopOnClick() {
     const workshopDescriptionInput = document.getElementById('add-workshop-description') as HTMLInputElement
     const workshopMinVolunteersInput = document.getElementById('add-workshop-min_volunteers') as HTMLInputElement
     const workshopCapacityInput = document.getElementById('add-workshop-capacity') as HTMLInputElement
+    const overflowInput = document.getElementById('add-workshop-overflow') as HTMLInputElement
     const workshopDifficultySelect = document.getElementById('difficulty-selection-container') as HTMLInputElement
     const workshopTypeSelect = document.getElementById('workshop-type-selection-container') as HTMLDivElement
 
@@ -89,6 +90,7 @@ function addWorkshopOnClick() {
         difficulty_id: Number(difficultyId),
         min_volunteers: Number(workshopMinVolunteersInput.value),
         capacity: Number(workshopCapacityInput.value),
+        overflow: overflowInput.checked,
         workshop_type_id: Number(workshopTypeId)
     }
 
@@ -106,6 +108,7 @@ function workshopTypeSelectionGroupOnChange(value:string) {
     const minVolunteersBlock = document.getElementById('min-volunteers-block') as HTMLDivElement
     const capacityBlock = document.getElementById('capacity-block') as HTMLDivElement
     const difficultyBlock = document.getElementById('difficulty-block') as HTMLDivElement
+    const overflowBlock = document.getElementById('overflow-block') as HTMLDivElement
 
     const currentWorkshopType = workshopTypesMap[Number(value)]
 
@@ -118,9 +121,11 @@ function workshopTypeSelectionGroupOnChange(value:string) {
     if (currentWorkshopType.attendee_registration) {
         capacityBlock.style.display = 'block'
         difficultyBlock.style.display = 'block'
+        overflowBlock.style.display = 'block'
     } else {
         capacityBlock.style.display = 'none'
         difficultyBlock.style.display = 'none'
+        overflowBlock.style.display = 'none'
     }
 }
 

--- a/jams/static/ts/management/workshops/edit_workshop.ts
+++ b/jams/static/ts/management/workshops/edit_workshop.ts
@@ -28,6 +28,7 @@ async function prepEditWorkshopForm() {
     const descriptionInput = document.getElementById('edit-workshop-description') as HTMLInputElement
     const minVolunteersInput = document.getElementById('edit-workshop-min_volunteers') as HTMLInputElement
     const capacityInput = document.getElementById('edit-workshop-capacity') as HTMLInputElement
+    const overflowInput = document.getElementById('edit-workshop-overflow') as HTMLInputElement
 
     nameInput.value = WorkshopData.name
     descriptionInput.value = WorkshopData.description
@@ -39,6 +40,7 @@ async function prepEditWorkshopForm() {
         capacityInput.value = String(WorkshopData.capacity)
     }
 
+    overflowInput.checked = WorkshopData.overflow
 
     const difficultyLevelSelect = document.getElementById('difficulty-selection-container') as HTMLDivElement
     const workshopTypeSelect = document.getElementById('workshop-type-selection-container') as HTMLDivElement
@@ -221,6 +223,7 @@ function editWorkshopOnClick() {
     const workshopDescriptionInput = document.getElementById('edit-workshop-description') as HTMLInputElement
     const workshopMinVolunteersInput = document.getElementById('edit-workshop-min_volunteers') as HTMLInputElement
     const workshopCapacityInput = document.getElementById('edit-workshop-capacity') as HTMLInputElement
+    const overflowInput = document.getElementById('edit-workshop-overflow') as HTMLInputElement
     const workshopDifficultySelect = document.getElementById('difficulty-selection-container') as HTMLInputElement
     const workshopTypeSelect = document.getElementById('workshop-type-selection-container') as HTMLDivElement
 
@@ -248,6 +251,7 @@ function editWorkshopOnClick() {
         difficulty_id: Number(difficultyId),
         min_volunteers: Number(workshopMinVolunteersInput.value),
         capacity: Number(workshopCapacityInput.value),
+        overflow: overflowInput.checked,
         workshop_type_id: Number(workshopTypeId)
     }
 
@@ -264,6 +268,7 @@ function workshopTypeSelectionGroupOnChange(value:string) {
     const minVolunteersBlock = document.getElementById('min-volunteers-block') as HTMLDivElement
     const capacityBlock = document.getElementById('capacity-block') as HTMLDivElement
     const difficultyBlock = document.getElementById('difficulty-block') as HTMLDivElement
+    const overflowBlock = document.getElementById('overflow-block') as HTMLDivElement
 
     const currentWorkshopType = workshopTypesMap[Number(value)]
 
@@ -276,9 +281,11 @@ function workshopTypeSelectionGroupOnChange(value:string) {
     if (currentWorkshopType.attendee_registration) {
         capacityBlock.style.display = 'block'
         difficultyBlock.style.display = 'block'
+        overflowBlock.style.display = 'block'
     } else {
         capacityBlock.style.display = 'none'
         difficultyBlock.style.display = 'none'
+        overflowBlock.style.display = 'none'
     }
     
     SelectedWorkshopTypeId = currentWorkshopType.id

--- a/jams/templates/private/admin/settings/settings-general.html
+++ b/jams/templates/private/admin/settings/settings-general.html
@@ -76,6 +76,19 @@
                 </tr>
                 <tr>
                     <td class="setting-column">
+                        <p>Event Name Prefix Filter</p>
+                    </td>
+                    <td class="description-column">
+                        <label class="text-secondary">This is a filter for event names. If all your event names start with the same prefix. Eg: "My Event - February 2025" and "My Event - March 2025", you could set the filter to be "My Event - " and anywhere that shows the event name would remove the prefix part.</label>
+                    </td>
+                    <td class="value-column">
+                        <input id="prefix-filter-input" class="form-control" type="text" placeholder="My Event - "
+                        oninput="checkIfContentUpdated()">
+                    </td>
+                    <td>N/A</td>
+                </tr>
+                <tr>
+                    <td class="setting-column">
                         <p>Volunteer Streaks</p>
                     </td>
                     <td class="description-column">

--- a/jams/templates/private/management/locations_timeslots.html
+++ b/jams/templates/private/management/locations_timeslots.html
@@ -148,6 +148,15 @@
                         <span class="form-check-label">Break</span>
                     </label>
                 </div>
+                <div class="mb-3">
+                    <label class="form-check form-switch">
+                        <input id="add-timeslot-capacity-suggestion" class="form-check-input" type="checkbox">
+                        <span class="form-check-label">
+                            <span>Capacity Suggestion</span>
+                            <i title="Show a capacity suggestion helper in the schedule planner" class="ti ti-info-circle ms-2"></i>
+                        </span>
+                    </label>
+                </div>
             </div>
             <div class="modal-footer">
                 <a href="#" class="btn btn-link link-secondary" data-bs-dismiss="modal">
@@ -198,6 +207,15 @@
                     <label class="form-check form-switch">
                         <input id="edit-timeslot-is-break" class="form-check-input" type="checkbox">
                         <span class="form-check-label">Break</span>
+                    </label>
+                </div>
+                <div class="mb-3">
+                    <label class="form-check form-switch">
+                        <input id="edit-timeslot-capacity-suggestion" class="form-check-input" type="checkbox">
+                        <span class="form-check-label">
+                            <span>Capacity Suggestion</span>
+                            <i title="Show a capacity suggestion helper in the schedule planner" class="ti ti-info-circle ms-2"></i>
+                        </span>
                     </label>
                 </div>
             </div>

--- a/jams/templates/private/management/workshops/add_workshop.html
+++ b/jams/templates/private/management/workshops/add_workshop.html
@@ -53,6 +53,16 @@
             </div>
         </div>
 
+        <div id="overflow-block" class="mb-3">
+            <label class="form-check form-switch">
+                <input id="add-workshop-overflow" class="form-check-input" type="checkbox">
+                <span class="form-check-label">
+                    <span>Overflow</span>
+                    <i title="Should this workshop be treated as an overflow for the other workshops? Sort of a secondary workshop." class="ti ti-info-circle ms-2"></i>
+                </span>
+            </label>
+        </div>
+
         <div id="difficulty-block" class="mb-3">
             <label class="form-label">Difficulty</label>
             <div id="difficulty-selection-container" class="form-selectgroup">

--- a/jams/templates/private/management/workshops/edit_workshop.html
+++ b/jams/templates/private/management/workshops/edit_workshop.html
@@ -56,6 +56,16 @@
           </div>
         </div>
 
+        <div id="overflow-block" class="mb-3">
+          <label class="form-check form-switch">
+              <input id="edit-workshop-overflow" class="form-check-input" type="checkbox">
+              <span class="form-check-label">
+                  <span>Overflow</span>
+                  <i title="Should this workshop be treated as an overflow for the other workshops? Sort of a secondary workshop." class="ti ti-info-circle ms-2"></i>
+              </span>
+          </label>
+      </div>
+
         <div id="difficulty-block" class="mb-3">
           <label class="form-label">Difficulty</label>
           <div id="difficulty-selection-container" class="form-selectgroup">

--- a/jams/util/helper.py
+++ b/jams/util/helper.py
@@ -872,3 +872,9 @@ def get_latest_release():
         }
     except requests.RequestException:
         return None
+    
+def remove_event_name_prefix(event_name):
+    prefix = get_config_value(ConfigType.EVENT_PREFIX_FILTER)
+    if not prefix:
+        return event_name
+    return event_name.removeprefix(prefix).strip()


### PR DESCRIPTION
## Quality of Life changes

This PR adds a few small quality of life changes to JAMS

#### Capacity suggestions
Now on the schedule planner, it will give capacity suggestions for select timeslots. It will show the following:
- The number of normal (non overflow) slots available in a timeslot
- The number of overflow (shown inside round brackets) slots available in a timeslot
- 75% of number of attendees coming to an event. The 75% part is because not everyone signed up will come, so there is no point planning extra rooms for people who wont be there. Maybe this percentage can be configurable in the future.

**Example:**
![image](https://github.com/user-attachments/assets/8d843543-8ee1-477e-ac50-3dcf06e366ee)

#### Tooltips
- A tooltip has been added to allow you to see more details about the volunteers signed up to a workshop.
- The tooltip on volunteer attendance has been fixed to allow it to also work on mobile as tap events were not triggering a mouseover event.

**Volunteer signup tooltip:**
![image](https://github.com/user-attachments/assets/d671ed85-8fdc-4123-9aca-18513022620f)

#### Event Name Prefix
- This is an extra setting that allows you to set an event name prefix. Say all your events have the same prefix like:
"My Event - February 2025" and "My Event - March 2025", you could then set the prefix to be "My Event - " and those events would come up as: "February 2025" and "March 2025". This makes it a bit easier to read.

**Settings Screenshot:**
![image](https://github.com/user-attachments/assets/8ec8babe-1b05-405b-9137-9d6096275383)

