### PR TITLE
Basic SSE Implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Ignore Python virtual environment
-venv/
+*venv/
 
 # Ignore instance folder (for storing local configuration)
 instance/

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -27,7 +27,7 @@ seed_database(app)
 EOF
 
     # Start Gunicorn
-    exec gunicorn -k gevent  -w 1 -b 0.0.0.0:5000 "jams:create_app()"
+    exec gunicorn -k gevent -w 1 -b 0.0.0.0:5000 "jams:create_app()"
 else
     echo "Database is not ready. Waiting 10 seconds..."
     sleep 10

--- a/jams/__init__.py
+++ b/jams/__init__.py
@@ -8,7 +8,7 @@ from flask_security import Security, SQLAlchemyUserDatastore
 from uuid import UUID, uuid4
 import logging
 
-from jams.extensions import db, migrate, login_manager, oauth, WSS
+from jams.extensions import db, migrate, login_manager, oauth, WSS, logger
 from jams.models import User, Role, APIKey
 from jams.routes import routes_bp
 from jams.seeder import preform_seed
@@ -28,6 +28,10 @@ hmac_secret = None
 
 def create_app():
     app = Flask(__name__)
+
+    # Setup logger first
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s [%(name)s]: %(message)s")
+
     load_dotenv()
     app.config['SECRET_KEY']= os.getenv('SECRET_KEY', 'jams_flask_secret')
     app.config['SQLALCHEMY_DATABASE_URI'] = os.getenv('DATABASE_URL', 'postgresql://jams:jams@db:5432/jams-main')

--- a/jams/__init__.py
+++ b/jams/__init__.py
@@ -6,7 +6,7 @@ from dotenv import load_dotenv
 from flask import Flask
 from flask_security import Security, SQLAlchemyUserDatastore
 from uuid import UUID, uuid4
-
+import logging
 
 from jams.extensions import db, migrate, login_manager, oauth, WSS
 from jams.models import User, Role, APIKey
@@ -22,6 +22,7 @@ from jams.util.task_scheduler import TaskScheduler
 from jams.util import attendee_auth
 from jams.util.enums import APIKeyType
 
+logger = logging.getLogger(__name__)
 scheduler = None
 hmac_secret = None
 

--- a/jams/__init__.py
+++ b/jams/__init__.py
@@ -35,8 +35,14 @@ def create_app():
     load_dotenv()
     app.config['SECRET_KEY']= os.getenv('SECRET_KEY', 'jams_flask_secret')
     app.config['SQLALCHEMY_DATABASE_URI'] = os.getenv('DATABASE_URL', 'postgresql://jams:jams@db:5432/jams-main')
-    app.config["SECURITY_PASSWORD_SALT"] = os.environ.get( "SECURITY_PASSWORD_SALT", "ab3d3a0f6984c4f5hkao41509b097a7bd498e903f3c9b2eea667h16")
     app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
+    app.config['SQLALCHEMY_ENGINE_OPTIONS'] = {
+        "pool_size": 20,
+        "max_overflow": 20,
+        "pool_timeout": 30,
+        "pool_recycle": 1800
+    }
+    app.config["SECURITY_PASSWORD_SALT"] = os.environ.get( "SECURITY_PASSWORD_SALT", "ab3d3a0f6984c4f5hkao41509b097a7bd498e903f3c9b2eea667h16")
     app.config["SECURITY_REGISTERABLE"] = True
     app.config['SECURITY_POST_REGISTER_VIEW'] = '/private/dashboard'
     app.config['SECURITY_POST_LOGIN_VIEW'] = '/private/dashboard'

--- a/jams/default_config/endpoints.yaml
+++ b/jams/default_config/endpoints.yaml
@@ -61,8 +61,10 @@ groups:
       get_event_locations: routes.api_v1.private.admin.get_event_locations
       get_event_timeslots: routes.api_v1.private.admin.get_event_timeslots
       get_event_sessions: routes.api_v1.private.admin.get_event_sessions
+      get_event_sessions_sse: routes.api_v1.private.admin.get_event_sessions_sse
       get_event_volunteer_attendance: routes.api_v1.private.volunteer.get_event_attendance
       get_event_volunteer_signups: routes.api_v1.private.volunteer.get_event_volunteer_signups
+      get_event_volunteer_signups_sse: routes.api_v1.private.volunteer.get_event_volunteer_signups_sse
       get_event_attendees: routes.api_v1.private.event.get_attendees
       get_event_fire_list: routes.api_v1.private.event.get_fire_list
     write:

--- a/jams/default_config/pages.yaml
+++ b/jams/default_config/pages.yaml
@@ -211,7 +211,7 @@ pages:
       add_event_timeslot:
       delete_event_timeslot:
       # Sessions
-      get_event_sessions:
+      get_event_sessions_sse:
       add_workshop_to_session:
       remove_workshop_from_session:
       update_session_settings:
@@ -276,7 +276,7 @@ pages:
       get_users_public_info:
       get_event_volunteer_attendance:
       add_user_attendance:
-      get_event_volunteer_signups:
+      get_event_volunteer_signups_sse:
       add_volunteer_signup:
       remove_volunteer_signup:
       # Schedule Grid
@@ -287,7 +287,7 @@ pages:
       get_locations:
       get_event_timeslots:
       get_timeslots:
-      get_event_sessions:
+      get_event_sessions_sse:
       
 
   # Monitoring
@@ -382,7 +382,7 @@ pages:
       get_locations:
       get_event_timeslots:
       get_timeslots:
-      get_event_sessions:
+      get_event_sessions_sse:
       get_events_field:
         allowed_fields: id, name, date
 

--- a/jams/extensions.py
+++ b/jams/extensions.py
@@ -1,4 +1,5 @@
 import os
+import logging
 from dotenv import load_dotenv
 from flask_sqlalchemy import SQLAlchemy
 from sqlalchemy import text
@@ -13,6 +14,7 @@ from jams.util.websocket_server import WebsocketServer
 
 load_dotenv()
 
+logger = logging.getLogger('app')
 db = SQLAlchemy()
 migrate = Migrate()
 login_manager = LoginManager()

--- a/jams/static/ts/event/schedule_planner.ts
+++ b/jams/static/ts/event/schedule_planner.ts
@@ -36,8 +36,7 @@ const scheduleGridOptions:ScheduleGridOptions = {
     eventId: 1,
     edit: true,
     size: 200,
-    showPrivate: true,
-    autoRefresh: true
+    showPrivate: true
 }
 
 let scheduleGrid:ScheduleGrid

--- a/jams/static/ts/global/helper.ts
+++ b/jams/static/ts/global/helper.ts
@@ -896,3 +896,14 @@ export function createEventSelectionDropdown(currentEventId:number, eventDetails
 
     return eventSelectionDropdown
 }
+
+export function cloneMap<T>(
+    inputMap: Record<string | number, T>,
+    cloneFn?: (value: T) => T
+): Record<string | number, T> {
+    const tmpMap: Record<string | number, T> = {};
+    for (const [key, value] of Object.entries(inputMap)) {
+        tmpMap[key] = cloneFn ? cloneFn(value) : value
+    }
+    return tmpMap
+}

--- a/jams/static/ts/global/schedule_grid.ts
+++ b/jams/static/ts/global/schedule_grid.ts
@@ -4,7 +4,6 @@ import {
     getLocations,
     getTimeslots,
     getWorkshops,
-    getSessionsForEvent,
     getDifficultyLevels,
     addWorkshopToSession,
     removeWorkshopFromSession,
@@ -15,20 +14,20 @@ import {
     removeTimeslotFromEvent,
     getIconData,
     getWorkshopTypes,
-    getVolunteerSignupsForEvent,
     removeVolunteerSignup,
     addVolunteerSignup,
-    getAttendeesSignups,
     getWorkshopField,
     recalculateSessionCapacity,
     updateSessionSettings,
     getEventMetadata
 } from '@global/endpoints'
-import { DifficultyLevel, EventLocation, EventMetadata, EventTimeslot, Location, Session, sessionSettings, Timeslot, User, VolunteerSignup, Workshop, WorkshopType } from '@global/endpoints_interfaces'
-import {buildQueryString, emptyElement, allowDrop, waitForTransitionEnd, debounce, successToast, errorToast, buildUserAvatar, preloadUsersInfoMap, animateElement, isTouchDevice, hexToRgba, isNullEmptyOrSpaces} from '@global/helper'
+import { AttendeeSignup, DifficultyLevel, EventLocation, EventMetadata, EventTimeslot, Location, Session, sessionSettings, Timeslot, User, VolunteerSignup, Workshop, WorkshopType } from '@global/endpoints_interfaces'
+import {buildQueryString, emptyElement, allowDrop, waitForTransitionEnd, debounce, successToast, errorToast, buildUserAvatar, preloadUsersInfoMap, animateElement, isTouchDevice, hexToRgba, isNullEmptyOrSpaces, cloneMap} from '@global/helper'
 import {WorkshopCard, WorkshopCardOptions} from '@global/workshop_card'
 import { QueryStringData, ScheduleGridTimeslotCapacity } from './interfaces'
 import { addTooltipToElement, buildUserTooltip, hideAllTooltips } from './tooltips'
+import { getLiveAttendeeSignups, getLiveEventSessions, getLiveVolunteerSignups } from './sse_endpoints'
+import { SSEManager } from './sse_manager'
 
 type Icons = {[key: string]: any}
 
@@ -49,11 +48,9 @@ export interface ScheduleGridOptions {
     size?:number
     minSize?:number
     edit?:boolean
-    updateInterval?:number
     workshopCardOptions?:WorkshopCardOptions
     autoScale?:boolean
     autoResize?:boolean
-    autoRefresh?:boolean
     showPrivate?:boolean
     showVolunteerSignup?:boolean
     volunteerSignup?:boolean
@@ -66,6 +63,7 @@ export class ScheduleGrid {
     private scheduleContainer:HTMLElement|null
     private options:ScheduleGridOptions = {}
     private icons:Icons
+    private eventSessions:Session[] = []
     private sessionCount:number
     private eventLocations:EventLocation[]
     private eventTimeslots:EventTimeslot[]
@@ -73,9 +71,12 @@ export class ScheduleGrid {
     private timeslotsInEvent:TimeslotsInEvent[]
 
     private volunteerSignupsMap:Record<number, Set<number>> = {}
+    private volunteerSignupsMapOLD:Record<number, Set<number>> = {}
     private attendeeSignupCountsMap:Record<number, number> = {}
+    private attendeeSignupCountsMapOLD:Record<number, number> = {}
     private usersInfoMap:Record<number, Partial<User>> = {}
     private sessionsMap:Record<number, Session> = {}
+    private SessionsMapOLD:Record<number, Session> = {}
     private timeslotCapacityMap:Record<number, ScheduleGridTimeslotCapacity> = {}
 
     private difficultyLevels:DifficultyLevel[]
@@ -88,6 +89,11 @@ export class ScheduleGrid {
 
     private eventMetadata:EventMetadata;
 
+    // SSE handlers
+    private sessionsSSEHandler:SSEManager<[Session]> = null
+    private volunteerSignupsSSEHandler:SSEManager<[VolunteerSignup]> = null
+    private attendeeSignupsSSEHandler:SSEManager<[AttendeeSignup]> = null
+
 
     constructor(scheduleContainerId:string, options:ScheduleGridOptions = {}) {
         // Set options (use defaults for options not provided)
@@ -99,11 +105,9 @@ export class ScheduleGrid {
             size = 150,
             minSize = 150,
             edit = false,
-            updateInterval = 1,
             workshopCardOptions = {},
             autoScale = false,
             autoResize = false,
-            autoRefresh = true,
             showPrivate = true,
             showVolunteerSignup = false,
             volunteerSignup = false,
@@ -120,11 +124,9 @@ export class ScheduleGrid {
             size,
             minSize,
             edit,
-            updateInterval,
             workshopCardOptions,
             autoScale,
             autoResize,
-            autoRefresh,
             showPrivate,
             showVolunteerSignup,
             volunteerSignup,
@@ -175,6 +177,7 @@ export class ScheduleGrid {
         this.currentDragType = null
         this.scheduleValid = null
         this.fatalError = false
+        this.teardownSSEHandlers()
     }
 
     // Get the grid ready
@@ -255,6 +258,9 @@ export class ScheduleGrid {
         // Build the workshop card options based on the grid's options
         this.setupWorkshopCardOptions()
 
+        // Start SSE handlers
+        this.initialiseSSEHandlers()
+
         // Build the grid
         await this.updateSchedule()
 
@@ -265,13 +271,6 @@ export class ScheduleGrid {
                     this.updateGridSize(this)
                 }
             }
-
-            if (this.options.autoRefresh && this.options.updateInterval) {
-                // Run populate sessions x seconds
-                window.setInterval(() => {
-                    this.populateSessions()
-                }, this.options.updateInterval * 1000)
-            }
         }
 
         if (this.options.edit) {
@@ -279,37 +278,64 @@ export class ScheduleGrid {
         }
     }
 
-    async preloadVolunteerSignupsMap() {
-        this.volunteerSignupsMap = {}
-        const volunteerSignupsResponse = await getVolunteerSignupsForEvent(this.options.eventId)
-
-        volunteerSignupsResponse.data.forEach(signup => {
-            if (!this.volunteerSignupsMap[signup.session_id]) {
-                this.volunteerSignupsMap[signup.session_id] = new Set()
-            }
-            this.volunteerSignupsMap[signup.session_id].add(signup.user_id)
-        })
+    teardownSSEHandlers() {
+        this.sessionsSSEHandler?.stop()
+        this.volunteerSignupsSSEHandler?.stop()
+        this.attendeeSignupsSSEHandler?.stop()
     }
 
-    async preloadAttendeeSignupCounts() {
-        this.attendeeSignupCountsMap = {}
-        
-        const queryData:Partial<QueryStringData> = {
-            '$all_rows': true,
-            event_id: this.options.eventId,
+    initialiseSSEHandlers() {
+        // Clean up old SSE handlers
+        this.teardownSSEHandlers()
+
+        // Start the sessions SSE
+        const queryData = {
+            show_private: this.options.showPrivate,
+            '$all_rows': true
         }
-        const queryString = buildQueryString(queryData)
-        const attendeeSignupResponse = await getAttendeesSignups(queryString)
+        this.sessionsSSEHandler = getLiveEventSessions(this.options.eventId, queryData)
+        this.sessionsSSEHandler.onUpdate((data) => {
+            this.eventSessions = data
+            for (const session of this.eventSessions) {
+                this.sessionsMap[session.id] = session
+            }
+            this.SessionsMapOLD = cloneMap(this.sessionsMap, (session) => ({ ...session }))
+            this.populateSessions()
+        })
 
-        const signups = attendeeSignupResponse.data
+        if (this.options.volunteerSignup) {
+            // Start volunteer signups SSE
+            this.volunteerSignupsSSEHandler = getLiveVolunteerSignups(this.options.eventId)
+            this.volunteerSignupsSSEHandler.onUpdate((data) => {
+                this.volunteerSignupsMapOLD = cloneMap(this.volunteerSignupsMap, (set) => new Set(set))
 
-        if (signups) {
-            signups.forEach(signup => {
-                if (!this.attendeeSignupCountsMap[signup.session_id]) {
-                    this.attendeeSignupCountsMap[signup.session_id] = 0
-                }
+                this.volunteerSignupsMap = {}
+                data.forEach(signup => {
+                    if (!this.volunteerSignupsMap[signup.session_id]) {
+                        this.volunteerSignupsMap[signup.session_id] = new Set()
+                    }
+                    this.volunteerSignupsMap[signup.session_id].add(signup.user_id)
+                })
+                this.populateSessions()
+            })
+        }
 
-                this.attendeeSignupCountsMap[signup.session_id]++
+        if (this.options.showAttendeeSignupCounts) {
+            // Start attendee signups SSE
+            this.attendeeSignupsSSEHandler = getLiveAttendeeSignups(this.options.eventId)
+            this.attendeeSignupsSSEHandler.onUpdate((data) => {
+                this.attendeeSignupCountsMapOLD = cloneMap(this.attendeeSignupCountsMap)
+
+                this.attendeeSignupCountsMap = {}
+                data.forEach(signup => {
+                    if (!this.attendeeSignupCountsMap[signup.session_id]) {
+                        this.attendeeSignupCountsMap[signup.session_id] = 0
+                    }
+
+                    this.attendeeSignupCountsMap[signup.session_id]++
+                })
+
+                this.populateSessions()
             })
         }
     }
@@ -401,8 +427,7 @@ export class ScheduleGrid {
     async changeEvent(newEventId:number) {
         this.options.eventId = newEventId
         this.volunteerSignupsMap = {}
-        await this.preloadVolunteerSignupsMap()
-        await this.preloadAttendeeSignupCounts()
+        this.initialiseSSEHandlers()
         this.updateSchedule()
 
     }
@@ -950,38 +975,8 @@ export class ScheduleGrid {
 
     // Populate the session blocks with workshops that are assigned to them
     async populateSessions() {
-        // Get all the sessions for the given event
-        const data = {
-            show_private: this.options.showPrivate,
-            '$all_rows': true
-        }
-        const queryString = buildQueryString(data)
-        const sessionsResponse = await getSessionsForEvent(this.options.eventId, queryString)
-        let sessions = sessionsResponse.data
-
-        const oldSessionsMap:Record<number, Session> = this.sessionsMap
-        let sessionsMap:Record<number, Session> = {}
-        for (const session of sessions) {
-            sessionsMap[session.id] = session
-        }
-        this.sessionsMap = sessionsMap
-
-        const oldSignups:Record<number, Set<number>> = this.volunteerSignupsMap
-        let currentSignups:Record<number, Set<number>> = {}
-        if (this.options.showVolunteerSignup) {
-            await this.preloadVolunteerSignupsMap()
-            currentSignups = this.volunteerSignupsMap
-        }
-
-        const oldAttendeeSignupCounts:Record<number, number> = this.attendeeSignupCountsMap
-        let currentAttendeeSignupCounts:Record<number, number> = {}
-        if (this.options.showAttendeeSignupCounts) {
-            await this.preloadAttendeeSignupCounts()
-            currentAttendeeSignupCounts = this.attendeeSignupCountsMap
-        }
-
         // If the grid session count is not equal to the length of the sessions justed pulled down, reload the grid
-        if (this.sessionCount != sessions.length) {
+        if (this.sessionCount != this.eventSessions.length) {
             await this.updateSchedule()
             return
         }
@@ -991,7 +986,7 @@ export class ScheduleGrid {
         let sessionSignupCountsToUpdate:Session[] = []
 
         // Iterate over the sessions
-        for (const session of sessions) {
+        for (const session of Object.values(this.sessionsMap)) {
             let sessionBlock = document.getElementById(`session-${session.event_location_id}-${session.event_timeslot_id}`)
             if (!sessionBlock) {
                 continue
@@ -1047,10 +1042,10 @@ export class ScheduleGrid {
             // If volunteeres can signup on this grid, check for differences
             if (this.options.showVolunteerSignup) {
                 const areEqual = 
-                    oldSignups[session.id] === undefined && currentSignups[session.id] === undefined
+                    this.volunteerSignupsMapOLD[session.id] === undefined && this.volunteerSignupsMap[session.id] === undefined
                     ? true
-                    : oldSignups[session.id]?.size === currentSignups[session.id]?.size &&
-                    Array.from(oldSignups[session.id]).every((value, index) => value === Array.from(currentSignups[session.id])[index])
+                    : this.volunteerSignupsMapOLD[session.id]?.size === this.volunteerSignupsMap[session.id]?.size &&
+                    Array.from(this.volunteerSignupsMapOLD[session.id]).every((value, index) => value === Array.from(this.volunteerSignupsMap[session.id])[index])
 
                 if (!areEqual) {
                     if (!sessionWorkshopsToAdd.includes(session)) {
@@ -1059,17 +1054,18 @@ export class ScheduleGrid {
                 }
             }
 
+
             // If attendee signup counts are shown, check for a difference
             if (this.options.showAttendeeSignupCounts) {
                 const areEqual = 
                     ((
-                        oldAttendeeSignupCounts[session.id] === undefined && currentAttendeeSignupCounts[session.id] === undefined
+                        this.attendeeSignupCountsMapOLD[session.id] === undefined && this.attendeeSignupCountsMap[session.id] === undefined
                         ? true
-                        : oldAttendeeSignupCounts[session.id] === currentAttendeeSignupCounts[session.id]) &&
+                        : this.attendeeSignupCountsMapOLD[session.id] === this.attendeeSignupCountsMap[session.id]) &&
                     (
-                        oldSessionsMap[session.id] === undefined || sessionsMap[session.id] === undefined
+                        this.SessionsMapOLD[session.id] === undefined || this.sessionsMap[session.id] === undefined
                         ? true
-                        : oldSessionsMap[session.id].capacity === sessionsMap[session.id].capacity
+                        : this.SessionsMapOLD[session.id].capacity === this.sessionsMap[session.id].capacity
                     ))
 
                 if (!areEqual) {
@@ -1156,9 +1152,9 @@ export class ScheduleGrid {
                 if (this.options.showVolunteerSignup) {
                     let workshopSignups = 0
                     let selectedUserSignupUp = false
-                    if (currentSignups[workshop.session_id] !== null && currentSignups[workshop.session_id] !== undefined) {
-                        workshopSignups = currentSignups[workshop.session_id].size
-                        selectedUserSignupUp = currentSignups[workshop.session_id].has(this.options.userId)
+                    if (this.volunteerSignupsMap[workshop.session_id] !== null && this.volunteerSignupsMap[workshop.session_id] !== undefined) {
+                        workshopSignups = this.volunteerSignupsMap[workshop.session_id].size
+                        selectedUserSignupUp = this.volunteerSignupsMap[workshop.session_id].has(this.options.userId)
                     }
 
                     if (workshop.min_volunteers !== null && workshop.min_volunteers !== undefined) {
@@ -1174,7 +1170,7 @@ export class ScheduleGrid {
                             const numberOfAvatarsFit = Math.floor(this.options.width / 30)
 
                             let index = 0
-                            for (const userId of currentSignups[workshop.session_id]) {
+                            for (const userId of this.volunteerSignupsMap[workshop.session_id]) {
                                 const user = this.usersInfoMap[userId]
                                 if (!user) {
                                     continue
@@ -1207,7 +1203,7 @@ export class ScheduleGrid {
                             // Tooltip
                             const tooltipElement = document.createElement('div')
                             tooltipElement.classList.add('card')
-                            for (const userId of currentSignups[workshop.session_id]) {
+                            for (const userId of this.volunteerSignupsMap[workshop.session_id]) {
                                 const user = this.usersInfoMap[userId]
                                 if (!user) {
                                     continue
@@ -1239,6 +1235,13 @@ export class ScheduleGrid {
                                     hideAllTooltips()
                                     removeVolunteerSignup(this.options.eventId, this.options.userId, workshop.session_id).then((response) => {
                                         successToast(response.message)
+                                        const set = this.volunteerSignupsMap[workshop.session_id];
+                                        if (set) {
+                                            set.delete(this.options.userId)
+                                            if (set.size === 0) {
+                                                delete this.volunteerSignupsMap[workshop.session_id]
+                                            }
+                                        }
                                         this.populateSessions()
                                     }).catch((error) => {
                                         const errorMessage = error.responseJSON ? error.responseJSON.message : 'An unknown error occurred';
@@ -1255,6 +1258,12 @@ export class ScheduleGrid {
 
                                     addVolunteerSignup(this.options.eventId, this.options.userId, data).then((response) => {
                                         successToast(response.message)
+                                        const signup = response.data
+                                        if (!this.volunteerSignupsMap[signup.session_id]) {
+                                            this.volunteerSignupsMap[signup.session_id] = new Set()
+                                        }
+                                        this.volunteerSignupsMap[signup.session_id].add(signup.user_id)
+
                                         this.populateSessions()
                                     }).catch((error) => {
                                         const errorMessage = error.responseJSON ? error.responseJSON.message : 'An unknown error occurred';
@@ -1284,7 +1293,7 @@ export class ScheduleGrid {
 
                     if (signupCountElement) {
                         if (workshop.attendee_registration) {
-                            let signupCount = currentAttendeeSignupCounts[sessionId]
+                            let signupCount = this.attendeeSignupCountsMap[sessionId]
                             if (signupCount === null || signupCount === undefined) {
                                 signupCount = 0
                             }
@@ -1334,7 +1343,7 @@ export class ScheduleGrid {
         // Add each session's capacity to the capacity map
         if (this.options.edit) {
             this.timeslotCapacityMap = {}
-            for (const session of sessions) {    
+            for (const session of this.eventSessions) {    
                 if (!session.has_workshop) {
                     continue
                 }
@@ -1401,6 +1410,11 @@ export class ScheduleGrid {
                 }
             }
         }
+
+        // Store the old maps for comparision on next itteration
+        this.SessionsMapOLD = cloneMap(this.sessionsMap, (session) => ({ ...session }))
+        this.volunteerSignupsMapOLD = cloneMap(this.volunteerSignupsMap, (set) => new Set(set))
+        this.attendeeSignupCountsMapOLD = cloneMap(this.attendeeSignupCountsMap)
     }
 
     // Sets up the event listeners to allow columns (locations) to be dragged
@@ -1563,6 +1577,8 @@ export class ScheduleGrid {
 
             if (!isBreak) {
                 if (await addWorkshopToSession(sessionID, workshopID)) {
+                    this.sessionsMap[sessionID].has_workshop = true
+                    this.sessionsMap[sessionID].workshop_id = workshopID
                     await scheduleGrid.populateSessions()
                 }
             } else {
@@ -1579,6 +1595,8 @@ export class ScheduleGrid {
 
                 confirmDeleteModal.find('#confirm-place-button').click(async () => {
                     if (await addWorkshopToSession(sessionID, workshopID)) {
+                        this.sessionsMap[sessionID].has_workshop = true
+                        this.sessionsMap[sessionID].workshop_id = workshopID
                         await scheduleGrid.populateSessions()
                     }
                 });
@@ -1592,6 +1610,8 @@ export class ScheduleGrid {
     // Handle workshop delete event
     async workshopRemoveFunc(sessionId:number, scheduleGrid:ScheduleGrid) {
         if (await removeWorkshopFromSession(sessionId)) {
+            scheduleGrid.sessionsMap[sessionId].has_workshop = false
+            scheduleGrid.sessionsMap[sessionId].workshop_id = null
             await scheduleGrid.populateSessions()
         }
     }

--- a/jams/static/ts/global/sse_endpoints.ts
+++ b/jams/static/ts/global/sse_endpoints.ts
@@ -1,4 +1,6 @@
-import { LiveEventStats } from "./endpoints_interfaces";
+import { AttendeeSignup, LiveEventStats, Session, VolunteerSignup } from "./endpoints_interfaces";
+import { buildQueryString } from "./helper";
+import { QueryStringData } from "./interfaces";
 import { SSEManager } from "./sse_manager";
 
 const baseURL = '/api/v1'
@@ -7,6 +9,36 @@ export function getLiveEventStats():SSEManager<LiveEventStats> {
     const url = `${baseURL}/stats/live/stream`
 
     const sse = new SSEManager<LiveEventStats>(url)
+    sse.start()
+    return sse
+}
+
+export function getLiveEventSessions(eventId:number, queryData:any):SSEManager<[Session]> {
+    const queryString = buildQueryString(queryData)
+    const url = `${baseURL}/events/${eventId}/sessions/stream?${queryString}`
+
+    const sse = new SSEManager<[Session]>(url)
+    sse.start()
+    return sse
+}
+
+export function getLiveVolunteerSignups(eventId:number):SSEManager<[VolunteerSignup]> {
+    const url = `${baseURL}/events/${eventId}/volunteer_signups/stream`
+
+    const sse = new SSEManager<[VolunteerSignup]>(url)
+    sse.start()
+    return sse
+}
+
+export function getLiveAttendeeSignups(eventId:number):SSEManager<[AttendeeSignup]> {
+    const queryData:Partial<QueryStringData> = {
+                '$all_rows': true,
+                event_id: eventId,
+            }
+            const queryString = buildQueryString(queryData)
+    const url = `${baseURL}/attendee/signups/stream?${queryString}`
+
+    const sse = new SSEManager<[AttendeeSignup]>(url)
     sse.start()
     return sse
 }

--- a/jams/static/ts/global/sse_manager.ts
+++ b/jams/static/ts/global/sse_manager.ts
@@ -29,6 +29,7 @@ export class SSEManager<T> {
     }
 
     public stop():void {
+        console.log('Stopping SSE connection')
         if (this.eventSource) {
             this.eventSource.close()
             this.eventSource = null

--- a/jams/static/ts/monitoring/stats.ts
+++ b/jams/static/ts/monitoring/stats.ts
@@ -1,7 +1,6 @@
 import { getEventStats } from "@global/endpoints";
 import { LiveEventStats, Event } from "@global/endpoints_interfaces";
-import { EventDetails } from "@global/event_details";
-import { createEventSelectionDropdown, emptyElement, eventDropdownItemText, formatDateToShort, isDefined, isNullEmptyOrSpaces, preLoadEventDetails, removeSpinnerFromElement } from "@global/helper";
+import { createEventSelectionDropdown, emptyElement, eventDropdownItemText, isDefined, isNullEmptyOrSpaces, preLoadEventDetails, removeSpinnerFromElement } from "@global/helper";
 import { CheckInTrendStat, WorkshopPopularityStat } from "@global/interfaces";
 import { getLiveEventStats } from "@global/sse_endpoints";
 import ApexCharts from "apexcharts";

--- a/jams/templates/_attendee_workshop_layout.html
+++ b/jams/templates/_attendee_workshop_layout.html
@@ -15,6 +15,7 @@
 </head>
 
 <body class=" border-top-wide border-primary">
+    <div id="nav-refresh" refresh="false" style="display: none;"></div>
     <div id="nav-container"></div>
     <div class="page page-center">
         <div class="container-tight py-4 pt-5">

--- a/jams/util/database.py
+++ b/jams/util/database.py
@@ -1,5 +1,6 @@
-from jams.models import db, Event
-from jams.util import task_scheduler
+from flask import request
+from jams.models import db, Event, Session, VolunteerSignup
+from jams.util import helper, task_scheduler
 
 def create_event(name, description, date, start_date_time, end_date_time, capacity, password, active=True, external=False, external_id=None, external_url = None):
     event = Event(
@@ -20,3 +21,27 @@ def create_event(name, description, date, start_date_time, end_date_time, capaci
     task_scheduler.create_event_tasks(event)
 
     return event
+
+def fetch_event_sessions(event_id):
+    # Check if the event exists
+    Event.query.filter_by(id=event_id).first_or_404()
+    sessions = Session.query.filter_by(event_id=event_id).all()
+
+    mutable_args = request.args.to_dict()
+    mutable_args['event_id'] = str(event_id)
+    show_private_text = mutable_args.pop('show_private', None)
+    show_private = False
+    if show_private_text:
+        show_private = show_private_text.lower() == 'true'
+    
+    data, row_count = helper.filter_model_by_query_and_properties(Session, mutable_args, input_data=sessions, return_objects=True)
+    
+    tmp_data = data.copy()
+    for session in tmp_data:
+        if (not session.event_location.publicly_visible and not show_private) or (not session.event_timeslot.publicly_visible and not show_private) and not session.event_timeslot.timeslot.is_break:
+
+            data.remove(session)
+
+    return_obj = [session.to_dict() for session in data]
+    return return_obj
+    

--- a/jams/util/sse.py
+++ b/jams/util/sse.py
@@ -1,0 +1,57 @@
+import json
+import sys
+from functools import wraps
+from flask import Response, stream_with_context, request
+from jams.models import db
+
+try:
+    from gevent import sleep as smart_sleep
+except ImportError:
+    from time import sleep as smart_sleep
+
+def sse_stream(fetch_data_func, *, detect_changes=True, sleep_interval=1):
+    """
+    Wraps an SSE generator with common logic:
+    - Client disconnect detection
+    - DB session cleanup
+    - Error handling
+    - Optional change detection
+    """
+    @stream_with_context
+    def generator():
+        last_sent_data = None
+        try:
+            while True:
+                # Detect client disconnect (works best in prod when using gevent)
+                if request.environ.get('wsgi.input') and request.environ['wsgi.input'].closed:
+                    print("Client disconnected via wsgi.input.closed")
+                    break
+
+                try:
+                    current_data = fetch_data_func()
+
+                    # Only send if data changed (if enabled)
+                    if not detect_changes or current_data != last_sent_data:
+                        last_sent_data = current_data
+                        yield f"data: {json.dumps(current_data)}\n\n"
+                        sys.stdout.flush()
+                
+                except Exception as e:
+                    print(f"SSE loop error: {e}")
+                
+                finally:
+                    db.session.remove()
+                
+                smart_sleep(sleep_interval)
+        except GeneratorExit:
+            print("Client disconnected (GeneratorExit)")
+        except Exception as e:
+            print(f"SSE error: {e}")
+    return Response(
+        generator(),
+        content_type='text/event-stream',
+        headers={
+            "Cache-Control": "no-cache",
+            "X-Accel-Buffering": "no"
+        }
+    )

--- a/jams/util/sse.py
+++ b/jams/util/sse.py
@@ -54,6 +54,8 @@ def sse_stream(fetch_data_func, *, detect_changes=True, sleep_interval=1):
                 smart_sleep(sleep_interval)
         except GeneratorExit:
             print("Client disconnected (GeneratorExit)")
+        except (ConnectionResetError, BrokenPipeError):
+            print("Client forcibly closed the connection")
         except Exception as e:
             print(f"SSE error: {e}")
     return Response(

--- a/jams/util/sse.py
+++ b/jams/util/sse.py
@@ -3,11 +3,16 @@ import sys
 from functools import wraps
 from flask import Response, stream_with_context, request
 from jams.models import db
+import logging
+logger = logging.getLogger(__name__)
 
 try:
     from gevent import sleep as smart_sleep
 except ImportError:
     from time import sleep as smart_sleep
+
+active_sse_connections = 0
+
 
 def sse_stream(fetch_data_func, *, detect_changes=True, sleep_interval=1):
     """
@@ -18,22 +23,29 @@ def sse_stream(fetch_data_func, *, detect_changes=True, sleep_interval=1):
     - Optional change detection
     """
 
-    def client_disconnected():
-        """Check if client has disconnected, compatible with Werkzeug and Gevent."""
+    def client_disconnected(environ):
+        """Check if the client has disconnected — Gevent-friendly."""
         try:
-            return request.environ.get('wsgi.input') and request.environ['wsgi.input'].closed
-        except AttributeError:
-            # Gevent's Body object doesn't support `.closed`
+            input_stream = environ.get("wsgi.input")
+            return hasattr(input_stream, "is_closed") and input_stream.is_closed()
+        except Exception as e:
+            logger.error(f"Error checking disconnect: {e}")
             return False
         
     @stream_with_context
     def generator():
+        global active_sse_connections
+        active_sse_connections += 1
+        logger.error(f"🔌 SSE connected — total: {active_sse_connections}")
+    
         last_sent_data = None
+        environ = request.environ
+
         try:
             while True:
                 # Detect client disconnect (works best in prod when using gevent)
-                if client_disconnected():
-                    print("Client disconnected")
+                if client_disconnected(environ):
+                    logger.error("Client disconnected")
                     break
 
                 try:
@@ -46,18 +58,23 @@ def sse_stream(fetch_data_func, *, detect_changes=True, sleep_interval=1):
                         sys.stdout.flush()
                 
                 except Exception as e:
-                    print(f"SSE loop error: {e}")
+                    logger.error(f"SSE loop error: {e}")
                 
                 finally:
                     db.session.remove()
                 
                 smart_sleep(sleep_interval)
+                yield ": keep-alive\n\n"
+
         except GeneratorExit:
-            print("Client disconnected (GeneratorExit)")
+            logger.error("Client disconnected (GeneratorExit)")
         except (ConnectionResetError, BrokenPipeError):
-            print("Client forcibly closed the connection")
+            logger.error("Client forcibly closed the connection")
         except Exception as e:
-            print(f"SSE error: {e}")
+            logger.error(f"SSE error: {e}")
+        finally:
+            active_sse_connections -= 1
+            logger.error(f"SSE cleaned up — remaining: {active_sse_connections}")
     return Response(
         generator(),
         content_type='text/event-stream',


### PR DESCRIPTION
This PR adds basic SSE to a few pages
- Schedule grid for sessions, volunteer signups and attendee signups
- Workshop signup for attendee signups

It uses a basic and quick method of checking the DB every second for updates and then pushing them out. In the future, I want to move to a redis pub/sub system. But this will work for now and will reduce the number of requests when viewing the schedule grid.

It includes a SSE wrapper that can be used to add new endpoints quickly. The wrapper does the following:
- Client disconnect detection
- DB session clean-up
- Error handling
- Optional change detection